### PR TITLE
Add web clock displaying API counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ This simple project displays a counter on a web page and updates it from a serve
 The page fetches `/api` every five seconds and animates the number toward the latest value.
 Below the counter a progress bar shows progress toward today's goal with the current
 sales value displayed inside the bar. Adjust the monthly goal using the slider or by
-editing the number next to it.
+editing the number next to it. The progress bar changes color along with the counter to reflect progress.

--- a/README.md
+++ b/README.md
@@ -12,4 +12,5 @@ This simple project displays a counter on a web page and updates it from a serve
 
 The page fetches `/api` every five seconds and animates the number toward the latest value.
 Below the counter a progress bar shows progress toward today's goal with the current
-sales value displayed inside the bar.
+sales value displayed inside the bar. Use the slider or numeric input to adjust the
+monthly goal on the fly.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Shopify Counter
+
+This simple project displays a counter on a web page and updates it from a serverless API.
+
+## Setup
+
+1. Install dependencies (none required besides Node 18+).
+2. Set the environment variables `URL_1` and `URL_2` with your Shopify counter endpoints.
+3. Start the development server with a tool like `vercel dev` or `node api/index.js`.
+4. Open `index.html` in your browser to see the counter.
+
+The page fetches `/api` every five seconds and animates the number toward the latest value.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This simple project displays a counter on a web page and updates it from a serve
 ## Setup
 
 1. Install dependencies (none required besides Node 18+).
-2. Set the environment variables `URL_1` and `URL_2` with your Shopify counter endpoints.
-3. Start the development server with a tool like `vercel dev` or `node api/index.js`.
+2. (Optional) Set the environment variables `URL_1` and `URL_2` with your Shopify counter endpoints.
+   Defaults are included for testing.
+3. Start the development server with `vercel dev`.
 4. Open `index.html` in your browser to see the counter.
 
 The page fetches `/api` every five seconds and animates the number toward the latest value.

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ This simple project displays a counter on a web page and updates it from a serve
 
 The page fetches `/api` every five seconds and animates the number toward the latest value.
 Below the counter a progress bar shows progress toward today's goal with the current
-sales value displayed inside the bar. Use the slider or numeric input to adjust the
-monthly goal on the fly.
+sales value displayed inside the bar. Adjust the monthly goal using the slider or by
+editing the number next to it.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ This simple project displays a counter on a web page and updates it from a serve
 4. Open `index.html` in your browser to see the counter.
 
 The page fetches `/api` every five seconds and animates the number toward the latest value.
+Below the counter a progress bar shows progress toward today's goal with the current
+sales value displayed inside the bar.

--- a/api/index.js
+++ b/api/index.js
@@ -1,10 +1,12 @@
-const fetch = require('node-fetch');
-
-const URL_1 = "https://smiirl-shopify.herokuapp.com/c/096a519a-f432-48da-beb2-c0ae6438e9e1";
-const URL_2 = "https://smiirl-shopify.herokuapp.com/c/7e429d3d-726a-44c8-9cae-b4dbe8e3f9bd";
+const URL_1 = process.env.URL_1;
+const URL_2 = process.env.URL_2;
 
 module.exports = async (req, res) => {
     try {
+        if (!URL_1 || !URL_2) {
+            throw new Error('Missing URL_1 or URL_2 environment variables');
+        }
+
         // Fetch data from both Shopify counters
         const [data1, data2] = await Promise.all([
             fetch(URL_1).then(res => res.json()),
@@ -18,6 +20,7 @@ module.exports = async (req, res) => {
         res.json({ number: total });
     } catch (error) {
         // If an error occurs, return 0 to avoid breaking the counter
+        console.error('Failed to fetch counters', error);
         res.json({ number: 0 });
     }
 };

--- a/api/index.js
+++ b/api/index.js
@@ -1,11 +1,11 @@
-const URL_1 = process.env.URL_1;
-const URL_2 = process.env.URL_2;
+// Shopify counter endpoints. Environment variables override the defaults
+const URL_1 = process.env.URL_1 ||
+    'https://smiirl-shopify.herokuapp.com/c/096a519a-f432-48da-beb2-c0ae6438e9e1';
+const URL_2 = process.env.URL_2 ||
+    'https://smiirl-shopify.herokuapp.com/c/7e429d3d-726a-44c8-9cae-b4dbe8e3f9bd';
 
 module.exports = async (req, res) => {
     try {
-        if (!URL_1 || !URL_2) {
-            throw new Error('Missing URL_1 or URL_2 environment variables');
-        }
 
         // Fetch data from both Shopify counters
         const [data1, data2] = await Promise.all([

--- a/index.html
+++ b/index.html
@@ -7,48 +7,107 @@
 <style>
 body {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   height: 100vh;
   margin: 0;
-  background: #000;
+  background-color: #dedede;
   font-family: 'Share Tech Mono', monospace;
 }
+#wrapper {
+  text-align: center;
+}
 #counter {
-  font-size: 30vw;
+  font-size: 20vw;
   line-height: 1;
-  color: #00ff00;
+  width: 100%;
+  color: #FF5733;
+}
+#target {
+  font-size: 5vw;
+}
+#slider-container {
+  margin-top: 20px;
 }
 </style>
 </head>
 <body>
-<div id="counter">0</div>
+<div id="wrapper">
+  <div id="counter">0</div>
+  <div id="target"></div>
+  <div id="slider-container">
+    <input type="range" id="goal-slider" min="100000" max="1000000" step="1000">
+    <div id="goal-label"></div>
+  </div>
+</div>
 <script>
+const slider = document.getElementById('goal-slider');
+const goalLabel = document.getElementById('goal-label');
+let monthlyGoal = 500000;
+let currentValue = 0;
+
+function dailyTarget() {
+  const now = new Date();
+  const days = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+  return (monthlyGoal / days) * now.getDate();
+}
+
+function updateGoalDisplay() {
+  goalLabel.textContent = 'Monthly goal: ' + monthlyGoal.toLocaleString();
+}
+
+function updateTargetDisplay(target) {
+  document.getElementById('target').textContent = target.toLocaleString();
+}
+
+function getColor(value, target) {
+  if (value >= target * 1.1) return '#DAF7A6';
+  if (value >= target * 0.9) return '#FFC300';
+  return '#FF5733';
+}
+
+function animateCounter(endValue, target) {
+  const element = document.getElementById('counter');
+  const start = parseInt(element.textContent.replace(/,/g, ''), 10) || 0;
+  const duration = 2000;
+  const startTime = performance.now();
+
+  function tick(now) {
+    const progress = Math.min((now - startTime) / duration, 1);
+    const value = Math.floor(start + (endValue - start) * progress);
+    element.textContent = value.toLocaleString();
+    element.style.color = getColor(value, target);
+    if (progress < 1) requestAnimationFrame(tick);
+  }
+  requestAnimationFrame(tick);
+}
+
 async function updateCounter() {
+  const target = dailyTarget();
+  updateTargetDisplay(target);
   try {
     const res = await fetch('/api');
     const data = await res.json();
-    animateCounter(data.number ?? 0);
+    const value = data.number ?? 0;
+    if (value !== currentValue) {
+      animateCounter(value, target);
+      currentValue = value;
+    } else {
+      document.getElementById('counter').style.color = getColor(value, target);
+    }
   } catch (err) {
     console.error('Failed to fetch counter:', err);
   }
 }
 
-function animateCounter(target) {
-  const element = document.getElementById('counter');
-  const start = parseInt(element.textContent.replace(/,/g, ''), 10) || 0;
-  const duration = 1000;
-  const startTime = performance.now();
-
-  function tick(now) {
-    const progress = Math.min((now - startTime) / duration, 1);
-    const value = Math.floor(start + (target - start) * progress);
-    element.textContent = value.toLocaleString();
-    if (progress < 1) requestAnimationFrame(tick);
-  }
-
-  requestAnimationFrame(tick);
-}
+slider.value = monthlyGoal;
+updateGoalDisplay();
+slider.addEventListener('input', () => {
+  monthlyGoal = Number(slider.value);
+  updateGoalDisplay();
+  updateCounter();
+});
 
 updateCounter();
 setInterval(updateCounter, 5000);

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ body {
   text-align: center;
 }
 #counter {
-  font-size: 30vw;
+  font-size: 20vw;
   line-height: 1;
   width: 100%;
   color: #f00;
@@ -36,6 +36,7 @@ body {
 </div>
 <script>
 const MONTHLY_GOAL = 500000;
+let currentValue = 0;
 
 function dailyTarget() {
   const now = new Date();
@@ -71,7 +72,10 @@ async function updateCounter() {
     const data = await res.json();
     const value = data.number ?? 0;
     document.getElementById('counter').style.color = value >= target ? '#0f0' : '#f00';
-    animateCounter(value);
+    if (value !== currentValue) {
+      animateCounter(value);
+      currentValue = value;
+    }
   } catch (err) {
     console.error('Failed to fetch counter:', err);
   }

--- a/index.html
+++ b/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Shopify Counter</title>
+<link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
+<style>
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+  background-color: #000;
+  color: #0f0;
+  font-family: 'Share Tech Mono', monospace;
+}
+#counter {
+  font-size: 5rem;
+}
+</style>
+</head>
+<body>
+<div id="counter">0</div>
+<script>
+async function updateCounter() {
+  try {
+    const res = await fetch('/api');
+    const data = await res.json();
+    document.getElementById('counter').textContent = data.number ?? '0';
+  } catch (err) {
+    console.error('Failed to fetch counter:', err);
+  }
+}
+
+updateCounter();
+setInterval(updateCounter, 5000);
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ body {
   text-align: center;
 }
 #counter {
-  font-size: 20vw;
+  font-size: 30vw;
   line-height: 1;
   width: 100%;
   color: #FF5733;

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ body {
   align-items: center;
   height: 100vh;
   margin: 0;
-  background-color: #808080;
+  background-color: #dedede;
   font-family: 'Share Tech Mono', monospace;
 }
 #wrapper {

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@ function updateTargetDisplay(target) {
 }
 
 function getColor(value, target) {
-  if (value >= target * 1.1) return '#DAF7A6';
+  if (value >= target * 1.1) return '#28a745';
   if (value >= target * 0.9) return '#FFC300';
   return '#FF5733';
 }

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ body {
   align-items: center;
   height: 100vh;
   margin: 0;
-  background-color: #b7b7b7;
+  background-color: #808080;
   font-family: 'Share Tech Mono', monospace;
 }
 #wrapper {

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ body {
 function animateCounter(target) {
   const element = document.getElementById('counter');
   const start = parseInt(element.textContent, 10) || 0;
-  const duration = 1000;
+  const duration = 2000;
   const startTime = performance.now();
 
   function tick(now) {

--- a/index.html
+++ b/index.html
@@ -11,118 +11,28 @@ body {
   align-items: center;
   height: 100vh;
   margin: 0;
-  background-color: #28a745;
+  background: #000;
   font-family: 'Share Tech Mono', monospace;
 }
-#wrapper {
-  text-align: center;
-}
 #counter {
-  font-size: 20vw;
+  font-size: 30vw;
   line-height: 1;
-  width: 100%;
-  color: #FF5733;
-}
-#target {
-  font-size: 5vw;
-  color: #0f0;
-}
-
-#controls {
-  margin-top: 1rem;
-}
-
-#goalLabel {
-  font-size: 2vw;
-  color: #fff;
+  color: #00ff00;
 }
 </style>
 </head>
 <body>
-<div id="wrapper">
-  <div id="counter">0</div>
-  <div id="target"></div>
-</div>
-<div id="controls">
-  <input type="range" id="goalSlider" min="100000" max="1000000" step="10000" value="500000">
-  <div id="goalLabel"></div>
-</div>
+<div id="counter">0</div>
 <script>
-let monthlyGoal = 500000;
-let currentValue = 0;
-const slider = document.getElementById('goalSlider');
-const goalLabel = document.getElementById('goalLabel');
-
-function updateGoalDisplay() {
-  goalLabel.textContent = monthlyGoal.toLocaleString();
-  slider.value = monthlyGoal;
-  const target = dailyTarget();
-  updateTargetDisplay(target);
-  document.getElementById('counter').style.color = getColor(currentValue, target);
-}
-
-slider.addEventListener('input', () => {
-  monthlyGoal = Number(slider.value);
-  updateGoalDisplay();
-  updateCounter();
-});
-
-function dailyTarget() {
-  const now = new Date();
-  const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
-  return (monthlyGoal / daysInMonth) * now.getDate();
-}
-
-function updateTargetDisplay(value) {
-  document.getElementById('target').textContent = Math.round(value).toLocaleString();
-}
-
-function getColor(value, target) {
-  if (value >= target * 1.1) {
-    return '#DAF7A6';
-  }
-  if (value >= target * 0.9) {
-    return '#FFC300';
-  }
-  return '#FF5733';
-}
-
-function animateCounter(endValue, target) {
-  const element = document.getElementById('counter');
-  const start = parseInt(element.textContent.replace(/,/g, ''), 10) || 0;
-  const duration = 2000;
-  const startTime = performance.now();
-
-  function tick(now) {
-    const progress = Math.min((now - startTime) / duration, 1);
-    const value = Math.floor(start + (endValue - start) * progress);
-    element.textContent = value.toLocaleString();
-    element.style.color = getColor(value, target);
-    if (progress < 1) requestAnimationFrame(tick);
-  }
-
-  requestAnimationFrame(tick);
-}
-
 async function updateCounter() {
-  const target = dailyTarget();
-  updateTargetDisplay(target);
   try {
     const res = await fetch('/api');
     const data = await res.json();
-    const value = data.number ?? 0;
-    if (value !== currentValue) {
-      animateCounter(value, target);
-      currentValue = value;
-    } else {
-      document.getElementById('counter').style.color = getColor(value, target);
-    }
+    document.getElementById('counter').textContent = data.number ?? '0';
   } catch (err) {
     console.error('Failed to fetch counter:', err);
   }
 }
-
-updateGoalDisplay();
 updateCounter();
 setInterval(updateCounter, 5000);
 </script>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ body {
   align-items: center;
   height: 100vh;
   margin: 0;
-  background-color: #000;
+  background-color: #dedede;
   font-family: 'Share Tech Mono', monospace;
 }
 #wrapper {

--- a/index.html
+++ b/index.html
@@ -56,6 +56,9 @@ const goalLabel = document.getElementById('goalLabel');
 function updateGoalDisplay() {
   goalLabel.textContent = monthlyGoal.toLocaleString();
   slider.value = monthlyGoal;
+  const target = dailyTarget();
+  updateTargetDisplay(target);
+  document.getElementById('counter').style.color = getColor(currentValue, target);
 }
 
 slider.addEventListener('input', () => {

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ body {
   align-items: center;
   height: 100vh;
   margin: 0;
-  background-color: #dedede;
+  background-color: #b7b7b7;
   font-family: 'Share Tech Mono', monospace;
 }
 #wrapper {

--- a/index.html
+++ b/index.html
@@ -28,22 +28,32 @@ body {
     font-size: 5vw;
   }
   #progress-container {
-    height: 20px;
+    position: relative;
+    height: 25px;
     background-color: #ccc;
     margin-top: 20px;
-    position: relative;
     width: fit-content;
+    font-family: 'Share Tech Mono', monospace;
   }
   #progress-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
     height: 100%;
     width: 0%;
     background-color: #FF5733;
+    z-index: 0;
+  }
+  #progress-text {
+    position: relative;
+    z-index: 1;
     display: flex;
+    justify-content: space-between;
     align-items: center;
-    justify-content: center;
+    height: 100%;
+    padding: 0 6px;
+    font-size: 2vw;
     color: #000;
-    font-size: 3vw;
-    font-family: 'Share Tech Mono', monospace;
   }
   #slider-container {
     margin-top: 20px;
@@ -56,6 +66,10 @@ body {
   <div id="target"></div>
   <div id="progress-container">
     <div id="progress-bar"></div>
+    <div id="progress-text">
+      <span id="sales-value"></span>
+      <span id="remaining-value"></span>
+    </div>
   </div>
   <div id="slider-container">
     <input type="range" id="goal-slider" min="100000" max="1000000" step="1000">
@@ -67,6 +81,8 @@ const slider = document.getElementById('goal-slider');
 const goalLabel = document.getElementById('goal-label');
 const progressBar = document.getElementById('progress-bar');
 const progressContainer = document.getElementById('progress-container');
+const progressSales = document.getElementById('sales-value');
+const progressRemaining = document.getElementById('remaining-value');
 const counterElement = document.getElementById('counter');
 let monthlyGoal = 500000;
 let currentValue = 0;
@@ -85,12 +101,13 @@ function updateTargetDisplay(target) {
   document.getElementById('target').textContent = target.toLocaleString();
 }
 
-function updateProgress(value, target) {
-  const percent = Math.min(value / target, 1) * 100;
+function updateProgress(value) {
+  const percent = Math.min(value / monthlyGoal, 1) * 100;
   progressBar.style.width = percent + '%';
-  progressBar.style.backgroundColor = getColor(value, target);
-  progressBar.textContent = Math.round(value).toLocaleString() + ' / ' +
-    Math.round(target).toLocaleString();
+  progressBar.style.backgroundColor = getColor(value, monthlyGoal);
+  progressSales.textContent = Math.round(value).toLocaleString();
+  const remaining = Math.max(monthlyGoal - value, 0);
+  progressRemaining.textContent = remaining.toLocaleString();
   syncProgressWidth();
 }
 
@@ -115,7 +132,7 @@ function animateCounter(endValue, target) {
     const value = Math.floor(start + (endValue - start) * progress);
     element.textContent = value.toLocaleString();
     element.style.color = getColor(value, target);
-    updateProgress(value, target);
+    updateProgress(value);
     if (progress < 1) requestAnimationFrame(tick);
   }
   requestAnimationFrame(tick);
@@ -124,7 +141,7 @@ function animateCounter(endValue, target) {
 async function updateCounter() {
   const target = dailyTarget();
   updateTargetDisplay(target);
-  updateProgress(currentValue, target);
+  updateProgress(currentValue);
   try {
     const res = await fetch('/api');
     const data = await res.json();
@@ -134,7 +151,7 @@ async function updateCounter() {
       currentValue = value;
     } else {
       document.getElementById('counter').style.color = getColor(value, target);
-      updateProgress(value, target);
+      updateProgress(value);
     }
   } catch (err) {
     console.error('Failed to fetch counter:', err);
@@ -147,7 +164,7 @@ slider.addEventListener('input', () => {
   monthlyGoal = Number(slider.value);
   updateGoalDisplay();
   const target = dailyTarget();
-  updateProgress(currentValue, target);
+  updateProgress(currentValue);
   updateCounter();
 });
 

--- a/index.html
+++ b/index.html
@@ -58,6 +58,12 @@ body {
   #slider-container {
     margin-top: 20px;
   }
+  #goal-input {
+    width: 120px;
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 1.5vw;
+    margin-left: 10px;
+  }
 </style>
 </head>
 <body>
@@ -73,12 +79,14 @@ body {
   </div>
   <div id="slider-container">
     <input type="range" id="goal-slider" min="100000" max="1000000" step="1000">
+    <input type="number" id="goal-input" min="100000" max="1000000" step="1000">
     <div id="goal-label"></div>
   </div>
 </div>
 <script>
 const slider = document.getElementById('goal-slider');
 const goalLabel = document.getElementById('goal-label');
+const goalInput = document.getElementById('goal-input');
 const progressBar = document.getElementById('progress-bar');
 const progressContainer = document.getElementById('progress-container');
 const progressSales = document.getElementById('sales-value');
@@ -95,6 +103,7 @@ function dailyTarget() {
 
 function updateGoalDisplay() {
   goalLabel.textContent = 'Monthly goal: ' + monthlyGoal.toLocaleString();
+  goalInput.value = monthlyGoal;
 }
 
 function updateTargetDisplay(target) {
@@ -172,6 +181,7 @@ async function updateCounter() {
 }
 
 slider.value = monthlyGoal;
+goalInput.value = monthlyGoal;
 updateGoalDisplay();
 slider.addEventListener('input', () => {
   monthlyGoal = Number(slider.value);
@@ -179,6 +189,18 @@ slider.addEventListener('input', () => {
   const target = dailyTarget();
   updateProgress(currentValue);
   updateCounter();
+});
+
+goalInput.addEventListener('change', () => {
+  const value = Number(goalInput.value);
+  if (!isNaN(value)) {
+    monthlyGoal = value;
+    slider.value = value;
+    updateGoalDisplay();
+    const target = dailyTarget();
+    updateProgress(currentValue);
+    updateCounter();
+  }
 });
 
 syncProgressWidth();

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ body {
   font-size: 20vw;
   line-height: 1;
   width: 100%;
-  color: #f00;
+  color: #FF5733;
 }
 #target {
   font-size: 5vw;
@@ -48,6 +48,16 @@ function updateTargetDisplay(value) {
   document.getElementById('target').textContent = Math.round(value).toLocaleString();
 }
 
+function getColor(value, target) {
+  if (value >= target * 1.1) {
+    return '#DAF7A6';
+  }
+  if (value >= target * 0.9) {
+    return '#FFC300';
+  }
+  return '#FF5733';
+}
+
 function animateCounter(target) {
   const element = document.getElementById('counter');
   const start = parseInt(element.textContent, 10) || 0;
@@ -71,7 +81,7 @@ async function updateCounter() {
     const res = await fetch('/api');
     const data = await res.json();
     const value = data.number ?? 0;
-    document.getElementById('counter').style.color = value >= target ? '#0f0' : '#f00';
+    document.getElementById('counter').style.color = getColor(value, target);
     if (value !== currentValue) {
       animateCounter(value);
       currentValue = value;

--- a/index.html
+++ b/index.html
@@ -28,15 +28,22 @@ body {
     font-size: 5vw;
   }
   #progress-container {
-    width: 80%;
     height: 20px;
     background-color: #ccc;
     margin-top: 20px;
+    position: relative;
+    width: fit-content;
   }
   #progress-bar {
     height: 100%;
     width: 0%;
     background-color: #FF5733;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #000;
+    font-size: 3vw;
+    font-family: 'Share Tech Mono', monospace;
   }
   #slider-container {
     margin-top: 20px;
@@ -59,6 +66,8 @@ body {
 const slider = document.getElementById('goal-slider');
 const goalLabel = document.getElementById('goal-label');
 const progressBar = document.getElementById('progress-bar');
+const progressContainer = document.getElementById('progress-container');
+const counterElement = document.getElementById('counter');
 let monthlyGoal = 500000;
 let currentValue = 0;
 
@@ -80,6 +89,13 @@ function updateProgress(value, target) {
   const percent = Math.min(value / target, 1) * 100;
   progressBar.style.width = percent + '%';
   progressBar.style.backgroundColor = getColor(value, target);
+  progressBar.textContent = Math.round(value).toLocaleString() + ' / ' +
+    Math.round(target).toLocaleString();
+  syncProgressWidth();
+}
+
+function syncProgressWidth() {
+  progressContainer.style.width = counterElement.offsetWidth + 'px';
 }
 
 function getColor(value, target) {
@@ -135,8 +151,10 @@ slider.addEventListener('input', () => {
   updateCounter();
 });
 
+syncProgressWidth();
 updateCounter();
 setInterval(updateCounter, 5000);
+window.addEventListener('resize', syncProgressWidth);
 </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -27,6 +27,15 @@ body {
   font-size: 5vw;
   color: #0f0;
 }
+
+#controls {
+  margin-top: 1rem;
+}
+
+#goalLabel {
+  font-size: 2vw;
+  color: #fff;
+}
 </style>
 </head>
 <body>
@@ -34,14 +43,31 @@ body {
   <div id="counter">0</div>
   <div id="target"></div>
 </div>
+<div id="controls">
+  <input type="range" id="goalSlider" min="100000" max="1000000" step="10000" value="500000">
+  <div id="goalLabel"></div>
+</div>
 <script>
-const MONTHLY_GOAL = 500000;
+let monthlyGoal = 500000;
 let currentValue = 0;
+const slider = document.getElementById('goalSlider');
+const goalLabel = document.getElementById('goalLabel');
+
+function updateGoalDisplay() {
+  goalLabel.textContent = monthlyGoal.toLocaleString();
+  slider.value = monthlyGoal;
+}
+
+slider.addEventListener('input', () => {
+  monthlyGoal = Number(slider.value);
+  updateGoalDisplay();
+  updateCounter();
+});
 
 function dailyTarget() {
   const now = new Date();
   const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
-  return (MONTHLY_GOAL / daysInMonth) * now.getDate();
+  return (monthlyGoal / daysInMonth) * now.getDate();
 }
 
 function updateTargetDisplay(value) {
@@ -93,6 +119,7 @@ async function updateCounter() {
   }
 }
 
+updateGoalDisplay();
 updateCounter();
 setInterval(updateCounter, 5000);
 </script>

--- a/index.html
+++ b/index.html
@@ -28,11 +28,28 @@ async function updateCounter() {
   try {
     const res = await fetch('/api');
     const data = await res.json();
-    document.getElementById('counter').textContent = data.number ?? '0';
+    animateCounter(data.number ?? 0);
   } catch (err) {
     console.error('Failed to fetch counter:', err);
   }
 }
+
+function animateCounter(target) {
+  const element = document.getElementById('counter');
+  const start = parseInt(element.textContent.replace(/,/g, ''), 10) || 0;
+  const duration = 1000;
+  const startTime = performance.now();
+
+  function tick(now) {
+    const progress = Math.min((now - startTime) / duration, 1);
+    const value = Math.floor(start + (target - start) * progress);
+    element.textContent = value.toLocaleString();
+    if (progress < 1) requestAnimationFrame(tick);
+  }
+
+  requestAnimationFrame(tick);
+}
+
 updateCounter();
 setInterval(updateCounter, 5000);
 </script>

--- a/index.html
+++ b/index.html
@@ -26,11 +26,27 @@ body {
 <body>
 <div id="counter">0</div>
 <script>
+function animateCounter(target) {
+  const element = document.getElementById('counter');
+  const start = parseInt(element.textContent, 10) || 0;
+  const duration = 1000;
+  const startTime = performance.now();
+
+  function tick(now) {
+    const progress = Math.min((now - startTime) / duration, 1);
+    const value = Math.floor(start + (target - start) * progress);
+    element.textContent = value;
+    if (progress < 1) requestAnimationFrame(tick);
+  }
+
+  requestAnimationFrame(tick);
+}
+
 async function updateCounter() {
   try {
     const res = await fetch('/api');
     const data = await res.json();
-    document.getElementById('counter').textContent = data.number ?? '0';
+    animateCounter(data.number ?? 0);
   } catch (err) {
     console.error('Failed to fetch counter:', err);
   }

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ body {
   text-align: center;
 }
 #counter {
-  font-size: 30vw;
+  font-size: 20vw;
   line-height: 1;
   width: 100%;
   color: #FF5733;

--- a/index.html
+++ b/index.html
@@ -111,8 +111,21 @@ function updateProgress(value) {
   syncProgressWidth();
 }
 
+function measureSixDigitWidth() {
+  const span = document.createElement('span');
+  span.textContent = '000000';
+  span.style.position = 'absolute';
+  span.style.visibility = 'hidden';
+  span.style.fontFamily = window.getComputedStyle(counterElement).fontFamily;
+  span.style.fontSize = window.getComputedStyle(counterElement).fontSize;
+  document.body.appendChild(span);
+  const width = span.offsetWidth;
+  document.body.removeChild(span);
+  return width;
+}
+
 function syncProgressWidth() {
-  progressContainer.style.width = counterElement.offsetWidth + 'px';
+  progressContainer.style.width = measureSixDigitWidth() + 'px';
 }
 
 function getColor(value, target) {

--- a/index.html
+++ b/index.html
@@ -113,10 +113,10 @@ function updateTargetDisplay(target) {
   document.getElementById('target').textContent = target.toLocaleString();
 }
 
-function updateProgress(value) {
+function updateProgress(value, color = getColor(value, dailyTarget())) {
   const percent = Math.min(value / monthlyGoal, 1) * 100;
   progressBar.style.width = percent + '%';
-  progressBar.style.backgroundColor = getColor(value, monthlyGoal);
+  progressBar.style.backgroundColor = color;
   progressSales.textContent = Math.round(value).toLocaleString();
   const remaining = Math.max(monthlyGoal - value, 0);
   progressRemaining.textContent = remaining.toLocaleString();
@@ -156,8 +156,9 @@ function animateCounter(endValue, target) {
     const progress = Math.min((now - startTime) / duration, 1);
     const value = Math.floor(start + (endValue - start) * progress);
     element.textContent = value.toLocaleString();
-    element.style.color = getColor(value, target);
-    updateProgress(value);
+    const color = getColor(value, target);
+    element.style.color = color;
+    updateProgress(value, color);
     if (progress < 1) requestAnimationFrame(tick);
   }
   requestAnimationFrame(tick);
@@ -166,7 +167,8 @@ function animateCounter(endValue, target) {
 async function updateCounter() {
   const target = dailyTarget();
   updateTargetDisplay(target);
-  updateProgress(currentValue);
+  const currentColor = getColor(currentValue, target);
+  updateProgress(currentValue, currentColor);
   try {
     const res = await fetch('/api');
     const data = await res.json();
@@ -175,8 +177,9 @@ async function updateCounter() {
       animateCounter(value, target);
       currentValue = value;
     } else {
-      document.getElementById('counter').style.color = getColor(value, target);
-      updateProgress(value);
+      const color = getColor(value, target);
+      document.getElementById('counter').style.color = color;
+      updateProgress(value, color);
     }
   } catch (err) {
     console.error('Failed to fetch counter:', err);
@@ -190,7 +193,7 @@ slider.addEventListener('input', () => {
   monthlyGoal = Number(slider.value);
   updateGoalDisplay();
   const target = dailyTarget();
-  updateProgress(currentValue);
+  updateProgress(currentValue, getColor(currentValue, target));
   updateCounter();
 });
 
@@ -202,7 +205,7 @@ goalLabel.addEventListener('blur', () => {
     slider.value = value;
     updateGoalDisplay();
     const target = dailyTarget();
-    updateProgress(currentValue);
+    updateProgress(currentValue, getColor(currentValue, target));
     updateCounter();
   } else {
     updateGoalDisplay();

--- a/index.html
+++ b/index.html
@@ -58,11 +58,16 @@ body {
   #slider-container {
     margin-top: 20px;
   }
-  #goal-input {
-    width: 120px;
-    font-family: 'Share Tech Mono', monospace;
-    font-size: 1.5vw;
-    margin-left: 10px;
+  #goal-label[contenteditable] {
+    display: inline-block;
+    min-width: 6ch;
+    padding: 2px 4px;
+    border: 1px dashed transparent;
+  }
+  #goal-label[contenteditable]:focus {
+    outline: none;
+    border-color: #666;
+    background-color: #fff;
   }
 </style>
 </head>
@@ -78,15 +83,14 @@ body {
     </div>
   </div>
   <div id="slider-container">
+    <label for="goal-slider">Monthly goal:</label>
     <input type="range" id="goal-slider" min="100000" max="1000000" step="1000">
-    <input type="number" id="goal-input" min="100000" max="1000000" step="1000">
-    <div id="goal-label"></div>
+    <span id="goal-label" contenteditable="true"></span>
   </div>
 </div>
 <script>
 const slider = document.getElementById('goal-slider');
 const goalLabel = document.getElementById('goal-label');
-const goalInput = document.getElementById('goal-input');
 const progressBar = document.getElementById('progress-bar');
 const progressContainer = document.getElementById('progress-container');
 const progressSales = document.getElementById('sales-value');
@@ -102,8 +106,7 @@ function dailyTarget() {
 }
 
 function updateGoalDisplay() {
-  goalLabel.textContent = 'Monthly goal: ' + monthlyGoal.toLocaleString();
-  goalInput.value = monthlyGoal;
+  goalLabel.textContent = monthlyGoal.toLocaleString();
 }
 
 function updateTargetDisplay(target) {
@@ -181,8 +184,8 @@ async function updateCounter() {
 }
 
 slider.value = monthlyGoal;
-goalInput.value = monthlyGoal;
 updateGoalDisplay();
+
 slider.addEventListener('input', () => {
   monthlyGoal = Number(slider.value);
   updateGoalDisplay();
@@ -191,15 +194,18 @@ slider.addEventListener('input', () => {
   updateCounter();
 });
 
-goalInput.addEventListener('change', () => {
-  const value = Number(goalInput.value);
-  if (!isNaN(value)) {
+goalLabel.addEventListener('blur', () => {
+  const digits = goalLabel.textContent.replace(/[^0-9]/g, '');
+  const value = Number(digits);
+  if (!isNaN(value) && value >= 100000 && value <= 1000000) {
     monthlyGoal = value;
     slider.value = value;
     updateGoalDisplay();
     const target = dailyTarget();
     updateProgress(currentValue);
     updateCounter();
+  } else {
+    updateGoalDisplay();
   }
 });
 

--- a/index.html
+++ b/index.html
@@ -12,20 +12,41 @@ body {
   height: 100vh;
   margin: 0;
   background-color: #000;
-  color: #0f0;
   font-family: 'Share Tech Mono', monospace;
+}
+#wrapper {
+  text-align: center;
 }
 #counter {
   font-size: 30vw;
   line-height: 1;
-  text-align: center;
   width: 100%;
+  color: #f00;
+}
+#target {
+  font-size: 5vw;
+  color: #0f0;
 }
 </style>
 </head>
 <body>
-<div id="counter">0</div>
+<div id="wrapper">
+  <div id="counter">0</div>
+  <div id="target"></div>
+</div>
 <script>
+const MONTHLY_GOAL = 500000;
+
+function dailyTarget() {
+  const now = new Date();
+  const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+  return (MONTHLY_GOAL / daysInMonth) * now.getDate();
+}
+
+function updateTargetDisplay(value) {
+  document.getElementById('target').textContent = Math.round(value).toLocaleString();
+}
+
 function animateCounter(target) {
   const element = document.getElementById('counter');
   const start = parseInt(element.textContent, 10) || 0;
@@ -35,7 +56,7 @@ function animateCounter(target) {
   function tick(now) {
     const progress = Math.min((now - startTime) / duration, 1);
     const value = Math.floor(start + (target - start) * progress);
-    element.textContent = value;
+    element.textContent = value.toLocaleString();
     if (progress < 1) requestAnimationFrame(tick);
   }
 
@@ -43,10 +64,14 @@ function animateCounter(target) {
 }
 
 async function updateCounter() {
+  const target = dailyTarget();
+  updateTargetDisplay(target);
   try {
     const res = await fetch('/api');
     const data = await res.json();
-    animateCounter(data.number ?? 0);
+    const value = data.number ?? 0;
+    document.getElementById('counter').style.color = value >= target ? '#0f0' : '#f00';
+    animateCounter(value);
   } catch (err) {
     console.error('Failed to fetch counter:', err);
   }

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ body {
   align-items: center;
   height: 100vh;
   margin: 0;
-  background-color: #dedede;
+  background-color: #28a745;
   font-family: 'Share Tech Mono', monospace;
 }
 #wrapper {

--- a/index.html
+++ b/index.html
@@ -58,16 +58,17 @@ function getColor(value, target) {
   return '#FF5733';
 }
 
-function animateCounter(target) {
+function animateCounter(endValue, target) {
   const element = document.getElementById('counter');
-  const start = parseInt(element.textContent, 10) || 0;
+  const start = parseInt(element.textContent.replace(/,/g, ''), 10) || 0;
   const duration = 2000;
   const startTime = performance.now();
 
   function tick(now) {
     const progress = Math.min((now - startTime) / duration, 1);
-    const value = Math.floor(start + (target - start) * progress);
+    const value = Math.floor(start + (endValue - start) * progress);
     element.textContent = value.toLocaleString();
+    element.style.color = getColor(value, target);
     if (progress < 1) requestAnimationFrame(tick);
   }
 
@@ -81,10 +82,11 @@ async function updateCounter() {
     const res = await fetch('/api');
     const data = await res.json();
     const value = data.number ?? 0;
-    document.getElementById('counter').style.color = getColor(value, target);
     if (value !== currentValue) {
-      animateCounter(value);
+      animateCounter(value, target);
       currentValue = value;
+    } else {
+      document.getElementById('counter').style.color = getColor(value, target);
     }
   } catch (err) {
     console.error('Failed to fetch counter:', err);

--- a/index.html
+++ b/index.html
@@ -16,7 +16,10 @@ body {
   font-family: 'Share Tech Mono', monospace;
 }
 #counter {
-  font-size: 5rem;
+  font-size: 30vw;
+  line-height: 1;
+  text-align: center;
+  width: 100%;
 }
 </style>
 </head>

--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@ function updateProgress(value) {
 
 function measureSixDigitWidth() {
   const span = document.createElement('span');
-  span.textContent = '000000';
+  span.textContent = '888,888';
   span.style.position = 'absolute';
   span.style.visibility = 'hidden';
   span.style.fontFamily = window.getComputedStyle(counterElement).fontFamily;

--- a/index.html
+++ b/index.html
@@ -24,18 +24,32 @@ body {
   width: 100%;
   color: #FF5733;
 }
-#target {
-  font-size: 5vw;
-}
-#slider-container {
-  margin-top: 20px;
-}
+  #target {
+    font-size: 5vw;
+  }
+  #progress-container {
+    width: 80%;
+    height: 20px;
+    background-color: #ccc;
+    margin-top: 20px;
+  }
+  #progress-bar {
+    height: 100%;
+    width: 0%;
+    background-color: #FF5733;
+  }
+  #slider-container {
+    margin-top: 20px;
+  }
 </style>
 </head>
 <body>
 <div id="wrapper">
   <div id="counter">0</div>
   <div id="target"></div>
+  <div id="progress-container">
+    <div id="progress-bar"></div>
+  </div>
   <div id="slider-container">
     <input type="range" id="goal-slider" min="100000" max="1000000" step="1000">
     <div id="goal-label"></div>
@@ -44,6 +58,7 @@ body {
 <script>
 const slider = document.getElementById('goal-slider');
 const goalLabel = document.getElementById('goal-label');
+const progressBar = document.getElementById('progress-bar');
 let monthlyGoal = 500000;
 let currentValue = 0;
 
@@ -59,6 +74,12 @@ function updateGoalDisplay() {
 
 function updateTargetDisplay(target) {
   document.getElementById('target').textContent = target.toLocaleString();
+}
+
+function updateProgress(value, target) {
+  const percent = Math.min(value / target, 1) * 100;
+  progressBar.style.width = percent + '%';
+  progressBar.style.backgroundColor = getColor(value, target);
 }
 
 function getColor(value, target) {
@@ -78,6 +99,7 @@ function animateCounter(endValue, target) {
     const value = Math.floor(start + (endValue - start) * progress);
     element.textContent = value.toLocaleString();
     element.style.color = getColor(value, target);
+    updateProgress(value, target);
     if (progress < 1) requestAnimationFrame(tick);
   }
   requestAnimationFrame(tick);
@@ -86,6 +108,7 @@ function animateCounter(endValue, target) {
 async function updateCounter() {
   const target = dailyTarget();
   updateTargetDisplay(target);
+  updateProgress(currentValue, target);
   try {
     const res = await fetch('/api');
     const data = await res.json();
@@ -95,6 +118,7 @@ async function updateCounter() {
       currentValue = value;
     } else {
       document.getElementById('counter').style.color = getColor(value, target);
+      updateProgress(value, target);
     }
   } catch (err) {
     console.error('Failed to fetch counter:', err);
@@ -106,6 +130,8 @@ updateGoalDisplay();
 slider.addEventListener('input', () => {
   monthlyGoal = Number(slider.value);
   updateGoalDisplay();
+  const target = dailyTarget();
+  updateProgress(currentValue, target);
   updateCounter();
 });
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "main": "api/index.js",
   "scripts": {
-    "start": "node api/index.js"
+    "start": "vercel dev"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,5 @@
   "main": "api/index.js",
   "scripts": {
     "start": "node api/index.js"
-  },
-  "dependencies": {
-    "node-fetch": "^2.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `index.html` with digital clock design
- fetch `/api` endpoint and refresh the counter every few seconds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842a1eebd108330a0392efb97e01917