### PR TITLE
Add Jest test script

### DIFF
--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -1,0 +1,31 @@
+const handler = require('../api/index');
+const fetch = require('node-fetch');
+
+jest.mock('node-fetch');
+
+afterEach(() => {
+  fetch.mockReset();
+});
+
+function createRes() {
+  return { json: jest.fn() };
+}
+
+test('returns sum of numbers from both counters', async () => {
+  fetch.mockResolvedValueOnce({ json: () => Promise.resolve({ number: 3 }) });
+  fetch.mockResolvedValueOnce({ json: () => Promise.resolve({ number: 4 }) });
+
+  const res = createRes();
+  await handler({}, res);
+
+  expect(res.json).toHaveBeenCalledWith({ number: 7 });
+});
+
+test('returns 0 when fetch fails', async () => {
+  fetch.mockRejectedValue(new Error('fail'));
+
+  const res = createRes();
+  await handler({}, res);
+
+  expect(res.json).toHaveBeenCalledWith({ number: 0 });
+});

--- a/package.json
+++ b/package.json
@@ -3,9 +3,13 @@
   "version": "1.0.0",
   "main": "api/index.js",
   "scripts": {
-    "start": "node api/index.js"
+    "start": "node api/index.js",
+    "test": "jest"
   },
   "dependencies": {
     "node-fetch": "^2.7.0"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add jest dev dependency and npm test script
- create tests for API handler

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68432eb7fac48330b2f8ac601b521e05