### PR TITLE
Add front-end with monthly goal form

### DIFF
--- a/goal.html
+++ b/goal.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Add Monthly Goal</title>
+    <style>
+    body { font-family: Arial, sans-serif; padding: 1em; }
+    label { display: block; margin: 0.5em 0; }
+    input[type=number] { width: 100%; padding: 0.5em; }
+    select { width: 100%; padding: 0.5em; }
+    button { margin-top: 1em; padding: 0.5em 1em; }
+    table { margin-top: 1em; border-collapse: collapse; width: 100%; }
+    table, th, td { border: 1px solid #ccc; }
+    th, td { padding: 0.5em; text-align: left; }
+    </style>
+</head>
+<body>
+
+<h1>Add Monthly Goal</h1>
+<form id="goal-form">
+  <label for="month">Month</label>
+  <select id="month"></select>
+
+  <label for="amount">Goal</label>
+  <input type="number" id="amount" placeholder="e.g. 500000">
+
+  <button type="submit">Save</button>
+</form>
+
+<table id="goals-table">
+  <thead>
+    <tr><th>Month</th><th>Goal</th></tr>
+  </thead>
+  <tbody></tbody>
+</table>
+
+<script>
+const monthSelect = document.getElementById('month');
+const monthNames = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December'
+];
+monthNames.forEach((name, index) => {
+  const opt = document.createElement('option');
+  opt.value = name;
+  opt.textContent = name;
+  monthSelect.appendChild(opt);
+});
+monthSelect.value = monthNames[new Date().getMonth()];
+
+function loadGoals() {
+  const goals = JSON.parse(localStorage.getItem('monthlyGoals') || '{}');
+  const tbody = document.querySelector('#goals-table tbody');
+  tbody.innerHTML = '';
+  Object.keys(goals).forEach(month => {
+    const row = document.createElement('tr');
+    row.innerHTML = `<td>${month}</td><td>${goals[month]}</td>`;
+    tbody.appendChild(row);
+  });
+}
+
+document.getElementById('goal-form').addEventListener('submit', (e) => {
+  e.preventDefault();
+  const month = monthSelect.value;
+  const amount = document.getElementById('amount').value;
+  const goals = JSON.parse(localStorage.getItem('monthlyGoals') || '{}');
+  goals[month] = amount;
+  localStorage.setItem('monthlyGoals', JSON.stringify(goals));
+  loadGoals();
+  e.target.reset();
+  monthSelect.value = monthNames[new Date().getMonth()];
+});
+
+loadGoals();
+</script>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Shopify Counter</title>
+    <style>
+    body { font-family: Arial, sans-serif; margin: 0; }
+    .menu { position: relative; }
+    .menu input[type=checkbox] { display: none; }
+    .menu label {
+        display: block;
+        padding: 1em;
+        background: #333;
+        color: white;
+        cursor: pointer;
+    }
+    .menu ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        background: #eee;
+        display: none;
+    }
+    .menu input[type=checkbox]:checked ~ ul {
+        display: block;
+    }
+    .menu li { border-bottom: 1px solid #ddd; }
+    .menu li a { display: block; padding: 1em; color: #333; text-decoration: none; }
+    </style>
+</head>
+<body>
+<div class="menu">
+  <input type="checkbox" id="toggle-menu">
+  <label for="toggle-menu">&#9776; Menu</label>
+  <ul>
+    <li><a href="goal.html">Add Monthly Goal</a></li>
+  </ul>
+</div>
+
+<h1>Shopify Counter</h1>
+<p>This site combines Shopify counters. Use the menu to add monthly goals.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add index.html with burger menu linking to monthly goal page
- add goal.html page to set goals in local storage with the current month preselected

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6843309dd8ac8330b7a2177d6d9935ea