### PR TITLE
Fix npm start/test issues

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,4 +1,3 @@
-const fetch = require('node-fetch');
 
 const URL_1 = "https://smiirl-shopify.herokuapp.com/c/096a519a-f432-48da-beb2-c0ae6438e9e1";
 const URL_2 = "https://smiirl-shopify.herokuapp.com/c/7e429d3d-726a-44c8-9cae-b4dbe8e3f9bd";

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "1.0.0",
   "main": "api/index.js",
   "scripts": {
-    "start": "node api/index.js"
-  },
-  "dependencies": {
-    "node-fetch": "^2.7.0"
+    "start": "node api/index.js",
+    "test": "node test.js"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+
+(async () => {
+  // basic smoke test to ensure the handler returns a number
+  const handler = require('./api/index');
+  const req = {}; // dummy request
+  const res = { json(data) { this.data = data; } };
+  await handler(req, res);
+  assert(typeof res.data.number === 'number');
+  console.log('Test passed');
+})();


### PR DESCRIPTION
## Summary
- remove deprecated node-fetch dependency
- add a minimal test script
- rely on Node's built-in `fetch`

## Testing
- `npm install`
- `npm start`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843328c78ac8330a5bfc45deaddfa15