### PR TITLE
Add monthly goal settings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ sales value displayed inside the bar. Adjust the monthly goal using the slider o
 editing the number next to it. The progress bar changes color along with the counter to reflect progress.
 
 The page now includes a small hamburger menu in the top-right corner for quick navigation links.
+Use the **Settings** link in that menu to open a dedicated page where you can adjust the monthly goal.
+The value is stored in `localStorage` so both pages share the same goal.

--- a/index.html
+++ b/index.html
@@ -101,9 +101,9 @@ body {
 <body>
 <div id="hamburger">&#9776;</div>
 <div id="nav-menu">
-  <a href="#">Home</a>
+  <a href="index.html">Home</a>
   <a href="#">Stats</a>
-  <a href="#">Settings</a>
+  <a href="settings.html">Settings</a>
 </div>
 <div id="wrapper">
   <div id="counter">0</div>
@@ -131,7 +131,7 @@ const progressRemaining = document.getElementById('remaining-value');
 const counterElement = document.getElementById('counter');
 const hamburger = document.getElementById('hamburger');
 const navMenu = document.getElementById('nav-menu');
-let monthlyGoal = 500000;
+let monthlyGoal = Number(localStorage.getItem('monthlyGoal')) || 500000;
 let currentValue = 0;
 
 hamburger.addEventListener('click', () => {
@@ -231,6 +231,7 @@ updateGoalDisplay();
 slider.addEventListener('input', () => {
   monthlyGoal = Number(slider.value);
   updateGoalDisplay();
+  localStorage.setItem('monthlyGoal', monthlyGoal);
   const target = dailyTarget();
   updateProgress(currentValue, getColor(currentValue, target));
   updateCounter();
@@ -249,6 +250,7 @@ goalLabel.addEventListener('blur', () => {
   } else {
     updateGoalDisplay();
   }
+  localStorage.setItem('monthlyGoal', monthlyGoal);
 });
 
 syncProgressWidth();

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Settings - Monthly Goal</title>
+<link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
+<style>
+body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+  background-color: #dedede;
+  font-family: 'Share Tech Mono', monospace;
+}
+#hamburger {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  font-size: 30px;
+  cursor: pointer;
+  user-select: none;
+}
+#nav-menu {
+  position: absolute;
+  top: 50px;
+  right: 10px;
+  background-color: rgba(255, 255, 255, 0.9);
+  border: 1px solid #ccc;
+  padding: 10px;
+  display: none;
+  font-size: 1.2em;
+}
+#nav-menu.open {
+  display: block;
+}
+#nav-menu a {
+  display: block;
+  text-decoration: none;
+  color: #333;
+  margin: 5px 0;
+}
+#slider-container {
+  margin-top: 20px;
+}
+#goal-label[contenteditable] {
+  display: inline-block;
+  min-width: 6ch;
+  padding: 2px 4px;
+  border: 1px dashed transparent;
+}
+#goal-label[contenteditable]:focus {
+  outline: none;
+  border-color: #666;
+  background-color: #fff;
+}
+</style>
+</head>
+<body>
+<div id="hamburger">&#9776;</div>
+<div id="nav-menu">
+  <a href="index.html">Home</a>
+  <a href="#">Stats</a>
+  <a href="settings.html">Settings</a>
+</div>
+<h1>Settings</h1>
+<div id="slider-container">
+  <label for="goal-slider">Monthly goal:</label>
+  <input type="range" id="goal-slider" min="100000" max="1000000" step="1000">
+  <span id="goal-label" contenteditable="true"></span>
+</div>
+<script>
+const slider = document.getElementById('goal-slider');
+const goalLabel = document.getElementById('goal-label');
+const hamburger = document.getElementById('hamburger');
+const navMenu = document.getElementById('nav-menu');
+
+let monthlyGoal = Number(localStorage.getItem('monthlyGoal')) || 500000;
+
+function updateGoalDisplay() {
+  goalLabel.textContent = monthlyGoal.toLocaleString();
+}
+
+hamburger.addEventListener('click', () => {
+  navMenu.classList.toggle('open');
+});
+
+slider.value = monthlyGoal;
+updateGoalDisplay();
+
+slider.addEventListener('input', () => {
+  monthlyGoal = Number(slider.value);
+  updateGoalDisplay();
+  localStorage.setItem('monthlyGoal', monthlyGoal);
+});
+
+goalLabel.addEventListener('blur', () => {
+  const digits = goalLabel.textContent.replace(/[^0-9]/g, '');
+  const value = Number(digits);
+  if (!isNaN(value) && value >= 100000 && value <= 1000000) {
+    monthlyGoal = value;
+    slider.value = value;
+  }
+  updateGoalDisplay();
+  localStorage.setItem('monthlyGoal', monthlyGoal);
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new `settings.html` page for adjusting monthly goals
- persist monthly goal in `localStorage`
- update links in the burger menu
- document settings page in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68437511c2c083309d4e3d28f4cf0fd4