### PR TITLE
Add API auth test

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -5,6 +5,11 @@ const URL_2 = process.env.URL_2 ||
     'https://smiirl-shopify.herokuapp.com/c/7e429d3d-726a-44c8-9cae-b4dbe8e3f9bd';
 
 module.exports = async (req, res) => {
+    const requiredKey = process.env.API_KEY;
+    if (requiredKey && req.headers['x-api-key'] !== requiredKey) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+    }
     try {
 
         // Fetch data from both Shopify counters

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "api/index.js",
   "scripts": {
-    "start": "vercel dev"
+    "start": "vercel dev",
+    "test": "node --test"
   }
 }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,17 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const handler = require('../api/index.js');
+
+// ensure API key is required
+
+test('returns 401 when api key is missing', async () => {
+  process.env.API_KEY = 'secret';
+  const req = { headers: {} };
+  let statusCode = 200;
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json(body) { this.body = body; }
+  };
+  await handler(req, res);
+  assert.strictEqual(statusCode, 401);
+});


### PR DESCRIPTION
## Summary
- enforce API key check in `api/index.js`
- add a `test` script
- add Node test ensuring the API rejects missing key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68437aceccdc8330aafbfe5251bb35ce