### PR TITLE
Implement API toggle feature

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -10,18 +10,20 @@ module.exports = async (req, res) => {
         res.status(401).json({ error: 'Unauthorized' });
         return;
     }
+
+    // Determine which sources to include based on query parameter
+    const source = req.query?.source;
+    const include1 = !source || source === 'both' || source === '1';
+    const include2 = !source || source === 'both' || source === '2';
+
     try {
+        const fetches = [];
+        if (include1) fetches.push(fetch(URL_1).then(res => res.json()));
+        if (include2) fetches.push(fetch(URL_2).then(res => res.json()));
 
-        // Fetch data from both Shopify counters
-        const [data1, data2] = await Promise.all([
-            fetch(URL_1).then(res => res.json()),
-            fetch(URL_2).then(res => res.json())
-        ]);
+        const results = await Promise.all(fetches);
+        const total = results.reduce((sum, d) => sum + (d.number || 0), 0);
 
-        // Combine the numbers
-        const total = (data1.number || 0) + (data2.number || 0);
-
-        // Return the combined JSON for Smiirl
         res.json({ number: total });
     } catch (error) {
         // If an error occurs, return 0 to avoid breaking the counter

--- a/index.html
+++ b/index.html
@@ -82,6 +82,10 @@ body {
     font-size: 2vw;
     color: #000;
   }
+  #api-controls {
+    margin-top: 10px;
+    font-size: 1.2vw;
+  }
   #slider-container {
     margin-top: 20px;
   }
@@ -115,6 +119,10 @@ body {
       <span id="remaining-value"></span>
     </div>
   </div>
+  <div id="api-controls">
+    <label><input type="checkbox" id="api1" checked> API 1</label>
+    <label><input type="checkbox" id="api2" checked> API 2</label>
+  </div>
   <div id="slider-container">
     <label for="goal-slider">Monthly goal:</label>
     <input type="range" id="goal-slider" min="100000" max="1000000" step="1000">
@@ -131,6 +139,8 @@ const progressRemaining = document.getElementById('remaining-value');
 const counterElement = document.getElementById('counter');
 const hamburger = document.getElementById('hamburger');
 const navMenu = document.getElementById('nav-menu');
+const api1Box = document.getElementById('api1');
+const api2Box = document.getElementById('api2');
 const now = new Date();
 // Use a YYYY-MM key so each month can store a separate goal
 const monthKey = now.toISOString().slice(0,7);
@@ -215,7 +225,13 @@ async function updateCounter() {
   const currentColor = getColor(currentValue, target);
   updateProgress(currentValue, currentColor);
   try {
-    const res = await fetch('/api');
+    let query = '';
+    const include1 = api1Box.checked;
+    const include2 = api2Box.checked;
+    if (include1 && !include2) query = '?source=1';
+    else if (!include1 && include2) query = '?source=2';
+    else if (!include1 && !include2) query = '?source=none';
+    const res = await fetch('/api' + query);
     const data = await res.json();
     const value = data.number ?? 0;
     if (value !== currentValue) {
@@ -244,6 +260,9 @@ slider.addEventListener('input', () => {
   updateProgress(currentValue, getColor(currentValue, target));
   updateCounter();
 });
+
+api1Box.addEventListener('change', updateCounter);
+api2Box.addEventListener('change', updateCounter);
 
 goalLabel.addEventListener('blur', () => {
   const digits = goalLabel.textContent.replace(/[^0-9]/g, '');

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -28,3 +28,35 @@ test('combines values from both counters', async () => {
   assert.strictEqual(call, 2);
   global.fetch = originalFetch;
 });
+
+test('fetches only first counter when source=1', async () => {
+  const originalFetch = global.fetch;
+  const urls = [];
+  global.fetch = async (url) => {
+    urls.push(url);
+    return { json: async () => ({ number: 5 }) };
+  };
+  process.env.API_KEY = '';
+  const req = { headers: {}, query: { source: '1' } };
+  const res = { json(body) { this.body = body; } };
+  await handler(req, res);
+  assert.deepStrictEqual(res.body, { number: 5 });
+  assert.strictEqual(urls.length, 1);
+  global.fetch = originalFetch;
+});
+
+test('fetches only second counter when source=2', async () => {
+  const originalFetch = global.fetch;
+  const urls = [];
+  global.fetch = async (url) => {
+    urls.push(url);
+    return { json: async () => ({ number: 7 }) };
+  };
+  process.env.API_KEY = '';
+  const req = { headers: {}, query: { source: '2' } };
+  const res = { json(body) { this.body = body; } };
+  await handler(req, res);
+  assert.deepStrictEqual(res.body, { number: 7 });
+  assert.strictEqual(urls.length, 1);
+  global.fetch = originalFetch;
+});


### PR DESCRIPTION
## Summary
- allow selecting which Shopify API to aggregate via `source` query
- add checkboxes on the front page to toggle APIs
- update counter logic to respect API selection
- test API with different `source` parameters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68495e2544788330a8fa9b4f5a10a3e3