### PR TITLE
Add configurable counter URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This simple project displays a counter on a web page and updates it from a serve
    Defaults are included for testing.
 3. Start the development server with `vercel dev`.
 4. Open `index.html` in your browser to see the counter.
+5. You can also specify custom counter URLs on the **Settings** page. They are stored in
+   `localStorage` under `counterUrl1` and `counterUrl2` and will be used on subsequent visits.
 
 The page fetches `/api` every five seconds and animates the number toward the latest value.
 Below the counter a progress bar shows progress toward today's goal with the current

--- a/api/index.js
+++ b/api/index.js
@@ -16,10 +16,18 @@ module.exports = async (req, res) => {
     const include1 = !source || source === 'both' || source === '1';
     const include2 = !source || source === 'both' || source === '2';
 
+    // Allow overriding URLs via query parameters when provided and valid
+    const url1 = req.query?.url1 && /^https?:\/\//.test(req.query.url1)
+        ? req.query.url1
+        : URL_1;
+    const url2 = req.query?.url2 && /^https?:\/\//.test(req.query.url2)
+        ? req.query.url2
+        : URL_2;
+
     try {
         const fetches = [];
-        if (include1) fetches.push(fetch(URL_1).then(res => res.json()));
-        if (include2) fetches.push(fetch(URL_2).then(res => res.json()));
+        if (include1) fetches.push(fetch(url1).then(res => res.json()));
+        if (include2) fetches.push(fetch(url2).then(res => res.json()));
 
         const results = await Promise.all(fetches);
         const total = results.reduce((sum, d) => sum + (d.number || 0), 0);

--- a/index.html
+++ b/index.html
@@ -225,13 +225,18 @@ async function updateCounter() {
   const currentColor = getColor(currentValue, target);
   updateProgress(currentValue, currentColor);
   try {
-    let query = '';
+    const params = new URLSearchParams();
     const include1 = api1Box.checked;
     const include2 = api2Box.checked;
-    if (include1 && !include2) query = '?source=1';
-    else if (!include1 && include2) query = '?source=2';
-    else if (!include1 && !include2) query = '?source=none';
-    const res = await fetch('/api' + query);
+    if (include1 && !include2) params.set('source', '1');
+    else if (!include1 && include2) params.set('source', '2');
+    else if (!include1 && !include2) params.set('source', 'none');
+    const url1 = localStorage.getItem('counterUrl1');
+    const url2 = localStorage.getItem('counterUrl2');
+    if (url1) params.set('url1', url1);
+    if (url2) params.set('url2', url2);
+    const query = params.toString();
+    const res = await fetch('/api' + (query ? '?' + query : ''));
     const data = await res.json();
     const value = data.number ?? 0;
     if (value !== currentValue) {

--- a/settings.html
+++ b/settings.html
@@ -77,6 +77,10 @@ body {
   <a href="#">Stats</a>
   <a href="settings.html">Settings</a>
 </div>
+<div id="api-url-container">
+  <label>Counter URL 1: <input type="text" id="url1"></label><br>
+  <label>Counter URL 2: <input type="text" id="url2"></label>
+</div>
 <h1>Monthly goals</h1>
 <table id="goals-table">
   <tr><th>Month</th><th>Goal</th></tr>
@@ -104,6 +108,12 @@ const goalLabel = document.getElementById('goal-label');
 const hamburger = document.getElementById('hamburger');
 const navMenu = document.getElementById('nav-menu');
 
+const url1Input = document.getElementById("url1");
+const url2Input = document.getElementById("url2");
+url1Input.value = localStorage.getItem("counterUrl1") || "";
+url2Input.value = localStorage.getItem("counterUrl2") || "";
+url1Input.addEventListener("blur", () => localStorage.setItem("counterUrl1", url1Input.value.trim()));
+url2Input.addEventListener("blur", () => localStorage.setItem("counterUrl2", url2Input.value.trim()));
 const now = new Date();
 // Use the same YYYY-MM key as the main page
 const monthKey = now.toISOString().slice(0,7);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -60,3 +60,19 @@ test('fetches only second counter when source=2', async () => {
   assert.strictEqual(urls.length, 1);
   global.fetch = originalFetch;
 });
+
+test('uses url query parameters when provided', async () => {
+  const originalFetch = global.fetch;
+  const urls = [];
+  global.fetch = async (url) => {
+    urls.push(url);
+    return { json: async () => ({ number: 2 }) };
+  };
+  process.env.API_KEY = '';
+  const req = { headers: {}, query: { url1: 'https://a.com', url2: 'https://b.com' } };
+  const res = { json(body) { this.body = body; } };
+  await handler(req, res);
+  assert.deepStrictEqual(urls, ['https://a.com', 'https://b.com']);
+  assert.deepStrictEqual(res.body, { number: 4 });
+  global.fetch = originalFetch;
+});


### PR DESCRIPTION
## Summary
- allow overriding counter endpoints via settings
- store URLs in localStorage and prefill in settings form
- pass stored URLs to `/api` as query params
- make API accept `url1` and `url2` parameters
- test new behaviour
- document custom URL feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68495efbbb308330b273b129e3a5b7bb