### PR TITLE
Add configurable counter URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ This simple project displays a counter on a web page and updates it from a serve
    Defaults are included for testing.
 3. Start the development server with `vercel dev`.
 4. Open `index.html` in your browser to see the counter.
+5. The **Settings** page lets you define any number of custom counter endpoints.
+   Each entry has a name and a URL and the list is saved in `localStorage` under
+   `counterApis`. These names appear on the home page where you can toggle each
+   API on or off. When no custom endpoints exist, the page falls back to the two
+   environment URLs and still lets you disable either one individually.
 
 The page fetches `/api` every five seconds and animates the number toward the latest value.
 Below the counter a progress bar shows progress toward today's goal with the current

--- a/index.html
+++ b/index.html
@@ -119,10 +119,7 @@ body {
       <span id="remaining-value"></span>
     </div>
   </div>
-  <div id="api-controls">
-    <label><input type="checkbox" id="api1" checked> API 1</label>
-    <label><input type="checkbox" id="api2" checked> API 2</label>
-  </div>
+  <div id="api-controls"></div>
   <div id="slider-container">
     <label for="goal-slider">Monthly goal:</label>
     <input type="range" id="goal-slider" min="100000" max="1000000" step="1000">
@@ -139,8 +136,51 @@ const progressRemaining = document.getElementById('remaining-value');
 const counterElement = document.getElementById('counter');
 const hamburger = document.getElementById('hamburger');
 const navMenu = document.getElementById('nav-menu');
-const api1Box = document.getElementById('api1');
-const api2Box = document.getElementById('api2');
+const apiControls = document.getElementById('api-controls');
+let apis = JSON.parse(localStorage.getItem('counterApis') || '[]');
+const old1 = localStorage.getItem('counterUrl1');
+const old2 = localStorage.getItem('counterUrl2');
+if (!apis.length && (old1 || old2)) {
+  if (old1) apis.push({ name: 'API 1', url: old1, enabled: true });
+  if (old2) apis.push({ name: 'API 2', url: old2, enabled: true });
+}
+// If no endpoints were saved the server defaults will be used
+const useCustomApis = apis.length > 0;
+
+function renderApiControls() {
+  apiControls.innerHTML = '';
+  if (useCustomApis) {
+    apis.forEach((api, idx) => {
+      const label = document.createElement('label');
+      const box = document.createElement('input');
+      box.type = 'checkbox';
+      box.checked = api.enabled !== false;
+      box.addEventListener('change', () => {
+        apis[idx].enabled = box.checked;
+        localStorage.setItem('counterApis', JSON.stringify(apis));
+        updateCounter();
+      });
+      label.appendChild(box);
+      label.append(' ' + (api.name || `API ${idx + 1}`));
+      apiControls.appendChild(label);
+    });
+  } else {
+    ['api1', 'api2'].forEach(id => {
+      const label = document.createElement('label');
+      const box = document.createElement('input');
+      box.type = 'checkbox';
+      box.id = id;
+      box.checked = true;
+      label.htmlFor = id;
+      label.appendChild(box);
+      label.append(' API ' + (id === 'api1' ? '1' : '2'));
+      box.addEventListener('change', updateCounter);
+      apiControls.appendChild(label);
+    });
+  }
+}
+
+renderApiControls();
 const now = new Date();
 // Use a YYYY-MM key so each month can store a separate goal
 const monthKey = now.toISOString().slice(0,7);
@@ -225,13 +265,20 @@ async function updateCounter() {
   const currentColor = getColor(currentValue, target);
   updateProgress(currentValue, currentColor);
   try {
-    let query = '';
-    const include1 = api1Box.checked;
-    const include2 = api2Box.checked;
-    if (include1 && !include2) query = '?source=1';
-    else if (!include1 && include2) query = '?source=2';
-    else if (!include1 && !include2) query = '?source=none';
-    const res = await fetch('/api' + query);
+    const params = new URLSearchParams();
+    if (useCustomApis) {
+      const active = apis.filter(a => a.enabled && a.url);
+      active.forEach(u => params.append('url', u.url));
+      if (!active.length) params.set('source', 'none');
+    } else {
+      const include1 = document.getElementById('api1').checked;
+      const include2 = document.getElementById('api2').checked;
+      if (include1 && !include2) params.set('source', '1');
+      else if (!include1 && include2) params.set('source', '2');
+      else if (!include1 && !include2) params.set('source', 'none');
+    }
+    const query = params.toString();
+    const res = await fetch('/api' + (query ? '?' + query : ''));
     const data = await res.json();
     const value = data.number ?? 0;
     if (value !== currentValue) {
@@ -260,9 +307,6 @@ slider.addEventListener('input', () => {
   updateProgress(currentValue, getColor(currentValue, target));
   updateCounter();
 });
-
-api1Box.addEventListener('change', updateCounter);
-api2Box.addEventListener('change', updateCounter);
 
 goalLabel.addEventListener('blur', () => {
   const digits = goalLabel.textContent.replace(/[^0-9]/g, '');

--- a/settings.html
+++ b/settings.html
@@ -77,6 +77,12 @@ body {
   <a href="#">Stats</a>
   <a href="settings.html">Settings</a>
 </div>
+<section id="api-section">
+  <h2>API endpoints</h2>
+  <div id="api-list"></div>
+  <button id="add-api">+ Add API</button>
+  <button id="save-apis">OK</button>
+</section>
 <h1>Monthly goals</h1>
 <table id="goals-table">
   <tr><th>Month</th><th>Goal</th></tr>
@@ -104,6 +110,55 @@ const goalLabel = document.getElementById('goal-label');
 const hamburger = document.getElementById('hamburger');
 const navMenu = document.getElementById('nav-menu');
 
+const apiList = document.getElementById('api-list');
+const addApiBtn = document.getElementById('add-api');
+const saveApisBtn = document.getElementById('save-apis');
+let apis = JSON.parse(localStorage.getItem('counterApis') || '[]');
+
+if (!apis.length) {
+  const old1 = localStorage.getItem('counterUrl1');
+  const old2 = localStorage.getItem('counterUrl2');
+  if (old1) apis.push({ name: 'API 1', url: old1 });
+  if (old2) apis.push({ name: 'API 2', url: old2 });
+}
+if (!apis.length) apis = [{ name: 'API 1', url: '' }, { name: 'API 2', url: '' }];
+
+function renderApiList() {
+  apiList.innerHTML = '';
+  apis.forEach((api, idx) => {
+    const div = document.createElement('div');
+    div.innerHTML = `<input class="api-url" placeholder="URL" type="text"> ` +
+                    `<input class="api-name" placeholder="Name" type="text"> ` +
+                    `<button class="remove-api">x</button>`;
+    const urlInput = div.querySelector('.api-url');
+    const nameInput = div.querySelector('.api-name');
+    urlInput.value = api.url;
+    nameInput.value = api.name;
+    div.querySelector('.remove-api').addEventListener('click', () => {
+      apis.splice(idx, 1);
+      renderApiList();
+    });
+    apiList.appendChild(div);
+  });
+}
+
+addApiBtn.addEventListener('click', () => {
+  apis.push({ name: '', url: '' });
+  renderApiList();
+});
+
+saveApisBtn.addEventListener('click', () => {
+  apis = Array.from(apiList.children).map(row => ({
+    url: row.querySelector('.api-url').value.trim(),
+    name: row.querySelector('.api-name').value.trim()
+  })).filter(a => a.url);
+  localStorage.setItem('counterApis', JSON.stringify(apis));
+  localStorage.removeItem('counterUrl1');
+  localStorage.removeItem('counterUrl2');
+  renderApiList();
+});
+
+renderApiList();
 const now = new Date();
 // Use the same YYYY-MM key as the main page
 const monthKey = now.toISOString().slice(0,7);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -60,3 +60,35 @@ test('fetches only second counter when source=2', async () => {
   assert.strictEqual(urls.length, 1);
   global.fetch = originalFetch;
 });
+
+test('uses url query parameters when provided', async () => {
+  const originalFetch = global.fetch;
+  const urls = [];
+  global.fetch = async (url) => {
+    urls.push(url);
+    return { json: async () => ({ number: 2 }) };
+  };
+  process.env.API_KEY = '';
+  const req = { headers: {}, query: { url: ['https://a.com', 'https://b.com'] } };
+  const res = { json(body) { this.body = body; } };
+  await handler(req, res);
+  assert.deepStrictEqual(urls, ['https://a.com', 'https://b.com']);
+  assert.deepStrictEqual(res.body, { number: 4 });
+  global.fetch = originalFetch;
+});
+
+test('legacy url1/url2 parameters still work', async () => {
+  const originalFetch = global.fetch;
+  const urls = [];
+  global.fetch = async (url) => {
+    urls.push(url);
+    return { json: async () => ({ number: 3 }) };
+  };
+  process.env.API_KEY = '';
+  const req = { headers: {}, query: { url1: 'https://x.com', url2: 'https://y.com' } };
+  const res = { json(body) { this.body = body; } };
+  await handler(req, res);
+  assert.deepStrictEqual(urls, ['https://x.com', 'https://y.com']);
+  assert.deepStrictEqual(res.body, { number: 6 });
+  global.fetch = originalFetch;
+});


### PR DESCRIPTION
## Summary
- allow overriding counter endpoints via settings
- store URLs in localStorage and prefill in settings form
- pass stored URLs to `/api` as query params
- make API accept `url1` and `url2` parameters
- test new behaviour
- document custom URL feature in README
- fix default handling when no custom endpoints are configured
- keep API toggles for default endpoints when no custom URLs configured

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68495efbbb308330b273b129e3a5b7bb