### PR TITLE
Migrate counter URLs to array

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This simple project displays a counter on a web page and updates it from a serve
 3. Start the development server with `vercel dev`.
 4. Open `index.html` in your browser to see the counter.
 5. You can also specify custom counter URLs on the **Settings** page. They are stored in
-   `localStorage` under `counterUrl1` and `counterUrl2` and will be used on subsequent visits.
+   `localStorage` under `counterApis` (migrated automatically from the old
+   `counterUrl1` and `counterUrl2` keys) and will be used on subsequent visits.
 
 The page fetches `/api` every five seconds and animates the number toward the latest value.
 Below the counter a progress bar shows progress toward today's goal with the current

--- a/index.html
+++ b/index.html
@@ -141,6 +141,20 @@ const hamburger = document.getElementById('hamburger');
 const navMenu = document.getElementById('nav-menu');
 const api1Box = document.getElementById('api1');
 const api2Box = document.getElementById('api2');
+// Migrate old counterUrl1/counterUrl2 values into a single array
+let apis = JSON.parse(localStorage.getItem('counterApis') || '[]');
+if (!apis.length) {
+  const old1 = localStorage.getItem('counterUrl1');
+  const old2 = localStorage.getItem('counterUrl2');
+  if (old1) apis[0] = old1;
+  if (old2) apis[1] = old2;
+  localStorage.setItem('counterApis', JSON.stringify(apis));
+  localStorage.removeItem('counterUrl1');
+  localStorage.removeItem('counterUrl2');
+}
+// Restore previous checkbox states
+api1Box.checked = JSON.parse(localStorage.getItem('api1Checked') ?? 'true');
+api2Box.checked = JSON.parse(localStorage.getItem('api2Checked') ?? 'true');
 const now = new Date();
 // Use a YYYY-MM key so each month can store a separate goal
 const monthKey = now.toISOString().slice(0,7);
@@ -231,8 +245,8 @@ async function updateCounter() {
     if (include1 && !include2) params.set('source', '1');
     else if (!include1 && include2) params.set('source', '2');
     else if (!include1 && !include2) params.set('source', 'none');
-    const url1 = localStorage.getItem('counterUrl1');
-    const url2 = localStorage.getItem('counterUrl2');
+    const url1 = apis[0];
+    const url2 = apis[1];
     if (url1) params.set('url1', url1);
     if (url2) params.set('url2', url2);
     const query = params.toString();
@@ -266,8 +280,14 @@ slider.addEventListener('input', () => {
   updateCounter();
 });
 
-api1Box.addEventListener('change', updateCounter);
-api2Box.addEventListener('change', updateCounter);
+api1Box.addEventListener('change', () => {
+  localStorage.setItem('api1Checked', api1Box.checked);
+  updateCounter();
+});
+api2Box.addEventListener('change', () => {
+  localStorage.setItem('api2Checked', api2Box.checked);
+  updateCounter();
+});
 
 goalLabel.addEventListener('blur', () => {
   const digits = goalLabel.textContent.replace(/[^0-9]/g, '');


### PR DESCRIPTION
## Summary
- migrate old `counterUrl1` and `counterUrl2` entries to new `counterApis` array
- remember checkbox selections between reloads
- document new storage key in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849651424c88330bbbafee099639b4f