### PR TITLE
Add Node version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This simple project displays a counter on a web page and updates it from a serve
 
 ## Setup
 
-1. Install dependencies (none required besides Node 18+).
+1. Install dependencies (Node 18 or newer is required but no extra packages are needed).
 2. (Optional) Set the environment variables `URL_1` and `URL_2` with your Shopify counter endpoints.
    Defaults are included for testing.
 3. Start the development server with `vercel dev`.

--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   "scripts": {
     "start": "vercel dev",
     "test": "node --test"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
## Summary
- require Node 18 or newer in package.json
- document Node version requirement in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68496b98bc948330a6d4649ac6e35d1f