### PR TITLE
Add customizable API URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ This simple project displays a counter on a web page and updates it from a serve
    Defaults are included for testing.
 3. Start the development server with `vercel dev`.
 4. Open `index.html` in your browser to see the counter.
-5. You can also specify custom counter URLs on the **Settings** page. They are stored in
-   `localStorage` under `counterApis` (migrated automatically from the old
-   `counterUrl1` and `counterUrl2` keys) and will be used on subsequent visits.
+5. You can also specify custom counter URLs on the **Settings** page. Enter them in the
+   fields labelled *Counter URL 1* and *Counter URL 2*. They are stored in
+   `localStorage` under `counterUrl1` and `counterUrl2` and will be used on subsequent
+   visits.
 
 The page fetches `/api` every five seconds and animates the number toward the latest value.
 Below the counter a progress bar shows progress toward today's goal with the current

--- a/index.html
+++ b/index.html
@@ -141,17 +141,6 @@ const hamburger = document.getElementById('hamburger');
 const navMenu = document.getElementById('nav-menu');
 const api1Box = document.getElementById('api1');
 const api2Box = document.getElementById('api2');
-// Migrate old counterUrl1/counterUrl2 values into a single array
-let apis = JSON.parse(localStorage.getItem('counterApis') || '[]');
-if (!apis.length) {
-  const old1 = localStorage.getItem('counterUrl1');
-  const old2 = localStorage.getItem('counterUrl2');
-  if (old1) apis[0] = old1;
-  if (old2) apis[1] = old2;
-  localStorage.setItem('counterApis', JSON.stringify(apis));
-  localStorage.removeItem('counterUrl1');
-  localStorage.removeItem('counterUrl2');
-}
 // Restore previous checkbox states
 api1Box.checked = JSON.parse(localStorage.getItem('api1Checked') ?? 'true');
 api2Box.checked = JSON.parse(localStorage.getItem('api2Checked') ?? 'true');
@@ -245,8 +234,8 @@ async function updateCounter() {
     if (include1 && !include2) params.set('source', '1');
     else if (!include1 && include2) params.set('source', '2');
     else if (!include1 && !include2) params.set('source', 'none');
-    const url1 = apis[0];
-    const url2 = apis[1];
+    const url1 = localStorage.getItem('counterUrl1');
+    const url2 = localStorage.getItem('counterUrl2');
     if (url1) params.set('url1', url1);
     if (url2) params.set('url2', url2);
     const query = params.toString();

--- a/settings.html
+++ b/settings.html
@@ -111,26 +111,13 @@ const navMenu = document.getElementById('nav-menu');
 const url1Input = document.getElementById("url1");
 const url2Input = document.getElementById("url2");
 
-// Load API URLs from the unified array, falling back to the old keys
-let apis = JSON.parse(localStorage.getItem('counterApis') || '[]');
-if (!apis.length) {
-  const old1 = localStorage.getItem('counterUrl1');
-  const old2 = localStorage.getItem('counterUrl2');
-  if (old1) apis[0] = old1;
-  if (old2) apis[1] = old2;
-}
-url1Input.value = apis[0] || '';
-url2Input.value = apis[1] || '';
+// Pre-fill fields from localStorage if available
+url1Input.value = localStorage.getItem('counterUrl1') || '';
+url2Input.value = localStorage.getItem('counterUrl2') || '';
 
 function saveUrls() {
-  apis[0] = url1Input.value.trim();
-  apis[1] = url2Input.value.trim();
-  localStorage.setItem('counterApis', JSON.stringify(apis));
-  // Keep legacy keys in sync
-  if (apis[0]) localStorage.setItem('counterUrl1', apis[0]);
-  else localStorage.removeItem('counterUrl1');
-  if (apis[1]) localStorage.setItem('counterUrl2', apis[1]);
-  else localStorage.removeItem('counterUrl2');
+  localStorage.setItem('counterUrl1', url1Input.value.trim());
+  localStorage.setItem('counterUrl2', url2Input.value.trim());
 }
 
 url1Input.addEventListener('blur', saveUrls);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -103,3 +103,19 @@ test('falls back to default url when url1 is invalid', async () => {
   assert.deepStrictEqual(res.body, { number: 1 });
   global.fetch = originalFetch;
 });
+
+test('uses custom url1 when source=1', async () => {
+  const originalFetch = global.fetch;
+  const urls = [];
+  global.fetch = async (url) => {
+    urls.push(url);
+    return { json: async () => ({ number: 9 }) };
+  };
+  process.env.API_KEY = '';
+  const req = { headers: {}, query: { source: '1', url1: 'https://custom.com' } };
+  const res = { json(body) { this.body = body; } };
+  await handler(req, res);
+  assert.deepStrictEqual(urls, ['https://custom.com']);
+  assert.deepStrictEqual(res.body, { number: 9 });
+  global.fetch = originalFetch;
+});


### PR DESCRIPTION
## Summary
- allow entering counter URL 1 and 2 from the Settings page
- read custom URLs when fetching the counter
- test using query parameters for custom URLs
- document how to use the new fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68496dd1137083309e49f8d2737accea