### PR TITLE
Add configurable API list

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -11,24 +11,38 @@ module.exports = async (req, res) => {
         return;
     }
 
-    // Determine which sources to include based on query parameter
-    const source = req.query?.source;
-    const include1 = !source || source === 'both' || source === '1';
-    const include2 = !source || source === 'both' || source === '2';
+    // If "url" query params are provided, use them directly.
+    // Supports repeated "url" parameters for multiple endpoints.
+    let urls = [];
+    if (req.query?.url) {
+        const provided = Array.isArray(req.query.url)
+            ? req.query.url
+            : [req.query.url];
+        urls = provided.filter(u => /^https?:\/\//.test(u));
+    } else {
+        // Determine which default sources to include based on query parameter
+        const source = req.query?.source;
+        const include1 = !source || source === 'both' || source === '1';
+        const include2 = !source || source === 'both' || source === '2';
 
-    // Build list of URLs to fetch, using query params when valid
-    const urls = [];
-    if (include1) {
-        const u = req.query?.url1 && /^https?:\/\//.test(req.query.url1)
-            ? req.query.url1
-            : URL_1;
-        urls.push(u);
+        // Build list of URLs to fetch, using query params when valid
+        if (include1) {
+            const u = req.query?.url1 && /^https?:\/\//.test(req.query.url1)
+                ? req.query.url1
+                : URL_1;
+            urls.push(u);
+        }
+        if (include2) {
+            const u = req.query?.url2 && /^https?:\/\//.test(req.query.url2)
+                ? req.query.url2
+                : URL_2;
+            urls.push(u);
+        }
     }
-    if (include2) {
-        const u = req.query?.url2 && /^https?:\/\//.test(req.query.url2)
-            ? req.query.url2
-            : URL_2;
-        urls.push(u);
+
+    if (!urls.length) {
+        res.json({ number: 0 });
+        return;
     }
 
     try {

--- a/index.html
+++ b/index.html
@@ -120,8 +120,7 @@ body {
     </div>
   </div>
   <div id="api-controls">
-    <label><input type="checkbox" id="api1" checked> API 1</label>
-    <label><input type="checkbox" id="api2" checked> API 2</label>
+    <div id="api-checkboxes"></div>
   </div>
   <div id="slider-container">
     <label for="goal-slider">Monthly goal:</label>
@@ -139,11 +138,35 @@ const progressRemaining = document.getElementById('remaining-value');
 const counterElement = document.getElementById('counter');
 const hamburger = document.getElementById('hamburger');
 const navMenu = document.getElementById('nav-menu');
-const api1Box = document.getElementById('api1');
-const api2Box = document.getElementById('api2');
-// Restore previous checkbox states
-api1Box.checked = JSON.parse(localStorage.getItem('api1Checked') ?? 'true');
-api2Box.checked = JSON.parse(localStorage.getItem('api2Checked') ?? 'true');
+const apiContainer = document.getElementById('api-checkboxes');
+
+let apiList = JSON.parse(localStorage.getItem('apiList') || '[]');
+if (apiList.length === 0) {
+  apiList = [
+    { url: '', name: 'API 1', enabled: true },
+    { url: '', name: 'API 2', enabled: true }
+  ];
+}
+
+function renderApiCheckboxes() {
+  apiContainer.innerHTML = '';
+  apiList.forEach((api, index) => {
+    const label = document.createElement('label');
+    const box = document.createElement('input');
+    box.type = 'checkbox';
+    box.checked = api.enabled !== false;
+    box.addEventListener('change', () => {
+      api.enabled = box.checked;
+      localStorage.setItem('apiList', JSON.stringify(apiList));
+      updateCounter();
+    });
+    label.appendChild(box);
+    label.appendChild(document.createTextNode(' ' + (api.name || `API ${index+1}`)));
+    apiContainer.appendChild(label);
+  });
+}
+
+renderApiCheckboxes();
 const now = new Date();
 // Use a YYYY-MM key so each month can store a separate goal
 const monthKey = now.toISOString().slice(0,7);
@@ -229,15 +252,11 @@ async function updateCounter() {
   updateProgress(currentValue, currentColor);
   try {
     const params = new URLSearchParams();
-    const include1 = api1Box.checked;
-    const include2 = api2Box.checked;
-    if (include1 && !include2) params.set('source', '1');
-    else if (!include1 && include2) params.set('source', '2');
-    else if (!include1 && !include2) params.set('source', 'none');
-    const url1 = localStorage.getItem('counterUrl1');
-    const url2 = localStorage.getItem('counterUrl2');
-    if (url1) params.set('url1', url1);
-    if (url2) params.set('url2', url2);
+    const enabled = apiList.filter(a => a.enabled !== false);
+    enabled.forEach(a => {
+      if (a.url) params.append('url', a.url);
+    });
+    if (enabled.length === 0) params.set('source', 'none');
     const query = params.toString();
     const res = await fetch('/api' + (query ? '?' + query : ''));
     const data = await res.json();
@@ -266,15 +285,6 @@ slider.addEventListener('input', () => {
   localStorage.setItem('monthlyGoals', JSON.stringify(monthlyGoals));
   const target = dailyTarget();
   updateProgress(currentValue, getColor(currentValue, target));
-  updateCounter();
-});
-
-api1Box.addEventListener('change', () => {
-  localStorage.setItem('api1Checked', api1Box.checked);
-  updateCounter();
-});
-api2Box.addEventListener('change', () => {
-  localStorage.setItem('api2Checked', api2Box.checked);
   updateCounter();
 });
 

--- a/settings.html
+++ b/settings.html
@@ -68,6 +68,14 @@ body {
 #goals-table input {
   width: 100px;
 }
+
+#api-section {
+  margin-top: 10px;
+}
+
+#api-list div {
+  margin-bottom: 5px;
+}
 </style>
 </head>
 <body>
@@ -77,10 +85,11 @@ body {
   <a href="#">Stats</a>
   <a href="settings.html">Settings</a>
 </div>
-<div id="api-url-container">
-  <label>Counter URL 1: <input type="text" id="url1"></label><br>
-  <label>Counter URL 2: <input type="text" id="url2"></label>
-</div>
+<section id="api-section">
+  <div id="api-list"></div>
+  <button type="button" id="add-api">+</button>
+  <button type="button" id="save-apis">OK</button>
+</section>
 <h1>Monthly goals</h1>
 <table id="goals-table">
   <tr><th>Month</th><th>Goal</th></tr>
@@ -108,20 +117,50 @@ const goalLabel = document.getElementById('goal-label');
 const hamburger = document.getElementById('hamburger');
 const navMenu = document.getElementById('nav-menu');
 
-const url1Input = document.getElementById("url1");
-const url2Input = document.getElementById("url2");
+const apiListEl = document.getElementById('api-list');
+const addApiBtn = document.getElementById('add-api');
+const saveApisBtn = document.getElementById('save-apis');
 
-// Pre-fill fields from localStorage if available
-url1Input.value = localStorage.getItem('counterUrl1') || '';
-url2Input.value = localStorage.getItem('counterUrl2') || '';
-
-function saveUrls() {
-  localStorage.setItem('counterUrl1', url1Input.value.trim());
-  localStorage.setItem('counterUrl2', url2Input.value.trim());
+let apiList = JSON.parse(localStorage.getItem('apiList') || '[]');
+if (apiList.length === 0) {
+  apiList = [
+    { url: '', name: 'API 1' },
+    { url: '', name: 'API 2' }
+  ];
 }
 
-url1Input.addEventListener('blur', saveUrls);
-url2Input.addEventListener('blur', saveUrls);
+function renderApiList() {
+  apiListEl.innerHTML = '';
+  apiList.forEach((api, index) => {
+    const row = document.createElement('div');
+    const urlInput = document.createElement('input');
+    urlInput.type = 'text';
+    urlInput.value = api.url || '';
+    urlInput.placeholder = 'URL';
+    urlInput.addEventListener('input', () => api.url = urlInput.value.trim());
+    const nameInput = document.createElement('input');
+    nameInput.type = 'text';
+    nameInput.value = api.name || '';
+    nameInput.placeholder = 'Navn';
+    nameInput.addEventListener('input', () => api.name = nameInput.value.trim());
+    row.textContent = `API ${index + 1}: `;
+    row.appendChild(urlInput);
+    row.appendChild(nameInput);
+    apiListEl.appendChild(row);
+  });
+}
+
+renderApiList();
+
+addApiBtn.addEventListener('click', () => {
+  apiList.push({ url: '', name: '' });
+  renderApiList();
+});
+
+saveApisBtn.addEventListener('click', () => {
+  localStorage.setItem('apiList', JSON.stringify(apiList));
+  alert('Saved');
+});
 const now = new Date();
 // Use the same YYYY-MM key as the main page
 const monthKey = now.toISOString().slice(0,7);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -77,6 +77,22 @@ test('uses url query parameters when provided', async () => {
   global.fetch = originalFetch;
 });
 
+test('combines numbers from multiple url params', async () => {
+  const originalFetch = global.fetch;
+  const urls = [];
+  global.fetch = async (url) => {
+    urls.push(url);
+    return { json: async () => ({ number: 1 }) };
+  };
+  process.env.API_KEY = '';
+  const req = { headers: {}, query: { url: ['https://a.com', 'https://b.com', 'https://c.com'] } };
+  const res = { json(body) { this.body = body; } };
+  await handler(req, res);
+  assert.deepStrictEqual(urls, ['https://a.com', 'https://b.com', 'https://c.com']);
+  assert.deepStrictEqual(res.body, { number: 3 });
+  global.fetch = originalFetch;
+});
+
 test('returns 0 when source=none', async () => {
   const originalFetch = global.fetch;
   let calls = 0;


### PR DESCRIPTION
## Summary
- allow `api/index.js` to accept repeated `url` query params
- render API checkboxes from a saved list in `index.html`
- add editable API list section in `settings.html`
- test combining multiple `url` parameters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849758598b88330867ac1513d7a11eb