### PR TITLE
Update README with API_KEY info and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,17 @@ editing the number next to it. The progress bar changes color along with the cou
 The page now includes a small hamburger menu in the top-right corner for quick navigation links.
 Use the **Settings** link in that menu to open a page with a table for recording monthly goals for the year.
 Each month's goal is stored separately in `localStorage`. When the month changes the counter page reads the goal for that month so the values persist without a backend.
+
+## API Access
+
+Set the `API_KEY` environment variable to restrict access to the `/api` route. When a key is set, requests must include the same value in the `x-api-key` header or the API responds with `401 Unauthorized`. Leave `API_KEY` unset to allow unrestricted access.
+
+## Running tests
+
+Run the test suite with:
+
+```bash
+npm test
+```
+
+This command executes `node --test` under the hood.


### PR DESCRIPTION
## Summary
- document the API_KEY environment variable
- add instructions on running tests with `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853e9a0ba948330a95dd03a5c175420