### PR TITLE
Add URL whitelist validation

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -4,7 +4,31 @@ const URL_1 = process.env.URL_1 ||
 const URL_2 = process.env.URL_2 ||
     'https://smiirl-shopify.herokuapp.com/c/7e429d3d-726a-44c8-9cae-b4dbe8e3f9bd';
 
+// Build list of allowed hostnames. The hostnames for the two default URLs are
+// always permitted and additional ones can be supplied via the ALLOWED_HOSTS
+// environment variable (comma separated).
+const DEFAULT_ALLOWED_HOSTS = [
+    new URL(URL_1).hostname,
+    new URL(URL_2).hostname,
+];
+function buildAllowedHosts() {
+    const extras = process.env.ALLOWED_HOSTS
+        ? process.env.ALLOWED_HOSTS.split(',').map(h => h.trim()).filter(Boolean)
+        : [];
+    return new Set([...DEFAULT_ALLOWED_HOSTS, ...extras]);
+}
+
+function hostnameAllowed(u, allowedHosts) {
+    try {
+        const hostname = new URL(u).hostname;
+        return allowedHosts.has(hostname);
+    } catch {
+        return false;
+    }
+}
+
 module.exports = async (req, res) => {
+    const ALLOWED_HOSTS = buildAllowedHosts();
     const requiredKey = process.env.API_KEY;
     if (requiredKey && req.headers['x-api-key'] !== requiredKey) {
         res.status(401).json({ error: 'Unauthorized' });
@@ -18,7 +42,14 @@ module.exports = async (req, res) => {
         const provided = Array.isArray(req.query.url)
             ? req.query.url
             : [req.query.url];
-        urls = provided.filter(u => /^https?:\/\//.test(u));
+        for (const u of provided) {
+            if (/^https?:\/\//.test(u) && hostnameAllowed(u, ALLOWED_HOSTS)) {
+                urls.push(u);
+            } else {
+                res.status(400).json({ error: 'URL not allowed' });
+                return;
+            }
+        }
     } else {
         // Determine which default sources to include based on query parameter
         const source = req.query?.source;
@@ -30,12 +61,20 @@ module.exports = async (req, res) => {
             const u = req.query?.url1 && /^https?:\/\//.test(req.query.url1)
                 ? req.query.url1
                 : URL_1;
+            if (!hostnameAllowed(u, ALLOWED_HOSTS)) {
+                res.status(400).json({ error: 'URL not allowed' });
+                return;
+            }
             urls.push(u);
         }
         if (include2) {
             const u = req.query?.url2 && /^https?:\/\//.test(req.query.url2)
                 ? req.query.url2
                 : URL_2;
+            if (!hostnameAllowed(u, ALLOWED_HOSTS)) {
+                res.status(400).json({ error: 'URL not allowed' });
+                return;
+            }
             urls.push(u);
         }
     }


### PR DESCRIPTION
## Summary
- restrict counter API to whitelist of allowed hostnames
- allow providing allowed hostnames via `ALLOWED_HOSTS` env variable
- update tests for new validation and add disallowed-host test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853e9a1c91483309284a6f63734a2d1