### PR TITLE
Implement fetch timeouts with AbortController

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ This simple project displays a counter on a web page and updates it from a serve
 1. Install dependencies (Node 18 or newer is required but no extra packages are needed).
 2. (Optional) Set the environment variables `URL_1` and `URL_2` with your Shopify counter endpoints.
    Defaults are included for testing.
-3. Start the development server with `vercel dev`.
-4. Open `index.html` in your browser to see the counter.
-5. You can also specify custom counter URLs on the **Settings** page. Enter them in the
+3. (Optional) Adjust the per-request timeout with `FETCH_TIMEOUT_MS` (defaults to 3000ms).
+4. Start the development server with `vercel dev`.
+5. Open `index.html` in your browser to see the counter.
+6. You can also specify custom counter URLs on the **Settings** page. Enter them in the
    fields labelled *Counter URL 1* and *Counter URL 2*. They are stored in
    `localStorage` under `counterUrl1` and `counterUrl2` and will be used on subsequent
    visits.


### PR DESCRIPTION
## Summary
- add per-request timeout with `AbortController`
- expose timeout via `FETCH_TIMEOUT_MS` environment variable
- test timeout behaviour and document environment variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853e9a26554833090a3711e332190c7