### PR TITLE
Improve API key comparison security

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -3,12 +3,21 @@ const URL_1 = process.env.URL_1 ||
     'https://smiirl-shopify.herokuapp.com/c/096a519a-f432-48da-beb2-c0ae6438e9e1';
 const URL_2 = process.env.URL_2 ||
     'https://smiirl-shopify.herokuapp.com/c/7e429d3d-726a-44c8-9cae-b4dbe8e3f9bd';
+const { timingSafeEqual } = require('crypto');
 
 module.exports = async (req, res) => {
     const requiredKey = process.env.API_KEY;
-    if (requiredKey && req.headers['x-api-key'] !== requiredKey) {
-        res.status(401).json({ error: 'Unauthorized' });
-        return;
+    if (requiredKey) {
+        const provided = req.headers['x-api-key'] || '';
+        const providedBuf = Buffer.from(provided);
+        const requiredBuf = Buffer.from(requiredKey);
+        const valid =
+            providedBuf.length === requiredBuf.length &&
+            timingSafeEqual(providedBuf, requiredBuf);
+        if (!valid) {
+            res.status(401).json({ error: 'Unauthorized' });
+            return;
+        }
     }
 
     // If "url" query params are provided, use them directly.

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -16,6 +16,22 @@ test('returns 401 when api key is missing', async () => {
   assert.strictEqual(statusCode, 401);
 });
 
+test('accepts request when api key matches', async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({ json: async () => ({ number: 1 }) });
+  process.env.API_KEY = 'secret';
+  const req = { headers: { 'x-api-key': 'secret' } };
+  let statusCode = 200;
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json(body) { this.body = body; }
+  };
+  await handler(req, res);
+  assert.strictEqual(statusCode, 200);
+  assert.deepStrictEqual(res.body, { number: 2 });
+  global.fetch = originalFetch;
+});
+
 test('combines values from both counters', async () => {
   const originalFetch = global.fetch;
   let call = 0;


### PR DESCRIPTION
## Summary
- replace direct API key check with `crypto.timingSafeEqual`
- add test confirming successful auth when key matches

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853e9a299088330a5aa8bde1dfab01e