### PR TITLE
Handle period query for Shopify counter

### DIFF
--- a/api/shopify-counter.js
+++ b/api/shopify-counter.js
@@ -16,7 +16,16 @@ async function fetchCount(shop, token, createdAtMin) {
 }
 
 module.exports = async (req, res) => {
-  const createdAtMin = req.query?.created_at_min;
+  const period = req.query?.period || 'month';
+  let createdAtMin;
+  const now = new Date();
+  if (period === 'year') {
+    createdAtMin = new Date(Date.UTC(now.getUTCFullYear(), 0, 1)).toISOString();
+  } else if (period === 'all') {
+    createdAtMin = undefined;
+  } else {
+    createdAtMin = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
+  }
   const requiredKey = process.env.API_KEY;
   if (requiredKey) {
     const provided = req.headers['x-api-key'] || '';
@@ -28,17 +37,28 @@ module.exports = async (req, res) => {
     }
   }
   const results = { butikk1: 0, butikk2: 0 };
-  let total = 0;
   try {
-    results.butikk1 = await fetchCount(SHOPIFY_SHOP_1, SHOPIFY_ADMIN_TOKEN_1, createdAtMin);
+    results.butikk1 = await fetchCount(
+      SHOPIFY_SHOP_1,
+      SHOPIFY_ADMIN_TOKEN_1,
+      createdAtMin
+    );
   } catch (err) {
     console.error('Failed to fetch shop 1 count', err);
+    res.status(502).json({ error: 'Failed to fetch count from shop 1' });
+    return;
   }
   try {
-    results.butikk2 = await fetchCount(SHOPIFY_SHOP_2, SHOPIFY_ADMIN_TOKEN_2, createdAtMin);
+    results.butikk2 = await fetchCount(
+      SHOPIFY_SHOP_2,
+      SHOPIFY_ADMIN_TOKEN_2,
+      createdAtMin
+    );
   } catch (err) {
     console.error('Failed to fetch shop 2 count', err);
+    res.status(502).json({ error: 'Failed to fetch count from shop 2' });
+    return;
   }
-  total = results.butikk1 + results.butikk2;
+  const total = results.butikk1 + results.butikk2;
   res.json({ number: total, ...results });
 };

--- a/test/shopify-counter.test.js
+++ b/test/shopify-counter.test.js
@@ -27,6 +27,75 @@ test('sums counts from both shops', async () => {
   global.fetch = originalFetch;
 });
 
+test('uses start of current month by default', async () => {
+  const originalFetch = global.fetch;
+  const urls = [];
+  global.fetch = async (url) => {
+    urls.push(url);
+    return { json: async () => ({ count: 1 }) };
+  };
+  process.env.API_KEY = '';
+  const req = { headers: {}, query: {} };
+  const res = createRes();
+  await handler(req, res);
+  const now = new Date();
+  const expected = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
+  assert.strictEqual(urls[0].searchParams.get('created_at_min'), expected);
+  assert.strictEqual(urls[1].searchParams.get('created_at_min'), expected);
+  global.fetch = originalFetch;
+});
+
+test('uses start of current year when period=year', async () => {
+  const originalFetch = global.fetch;
+  const urls = [];
+  global.fetch = async (url) => {
+    urls.push(url);
+    return { json: async () => ({ count: 1 }) };
+  };
+  process.env.API_KEY = '';
+  const req = { headers: {}, query: { period: 'year' } };
+  const res = createRes();
+  await handler(req, res);
+  const now = new Date();
+  const expected = new Date(Date.UTC(now.getUTCFullYear(), 0, 1)).toISOString();
+  assert.strictEqual(urls[0].searchParams.get('created_at_min'), expected);
+  assert.strictEqual(urls[1].searchParams.get('created_at_min'), expected);
+  global.fetch = originalFetch;
+});
+
+test('omits created_at_min when period=all', async () => {
+  const originalFetch = global.fetch;
+  const urls = [];
+  global.fetch = async (url) => {
+    urls.push(url);
+    return { json: async () => ({ count: 1 }) };
+  };
+  process.env.API_KEY = '';
+  const req = { headers: {}, query: { period: 'all' } };
+  const res = createRes();
+  await handler(req, res);
+  assert.strictEqual(urls[0].searchParams.has('created_at_min'), false);
+  assert.strictEqual(urls[1].searchParams.has('created_at_min'), false);
+  global.fetch = originalFetch;
+});
+
+test('returns error when a shop fetch fails', async () => {
+  const originalFetch = global.fetch;
+  let call = 0;
+  global.fetch = async () => {
+    call++;
+    if (call === 1) throw new Error('boom');
+    return { json: async () => ({ count: 1 }) };
+  };
+  process.env.API_KEY = '';
+  const req = { headers: {}, query: {} };
+  const res = createRes();
+  await handler(req, res);
+  assert.strictEqual(res.statusCode, 502);
+  assert.deepStrictEqual(res.body, { error: 'Failed to fetch count from shop 1' });
+  global.fetch = originalFetch;
+});
+
 test('returns 401 when api key missing', async () => {
   process.env.API_KEY = 'secret';
   const req = { headers: {} };


### PR DESCRIPTION
## Summary
- add `period` query param handling for monthly/yearly/all counts
- throw JSON errors for failed shop requests
- test period values and error handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853f3827fa48330ada5aba6e4b2d76b