### PR TITLE
Document configuration and add period filter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Example environment configuration for Shopify Counter
+# Provide the domains and admin tokens for up to two Shopify stores
+SHOPIFY_SHOP_1=
+SHOPIFY_ADMIN_TOKEN_1=
+SHOPIFY_SHOP_2=
+SHOPIFY_ADMIN_TOKEN_2=
+
+# Optional configuration for the original counter endpoint
+URL_1=
+URL_2=
+ALLOWED_HOSTS=
+
+# Optional API key to protect the endpoints
+API_KEY=

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This simple project displays a counter on a web page and updates it from a serve
 ## Setup
 
 1. Install dependencies (Node 18 or newer is required but no extra packages are needed).
-2. Set the environment variables `SHOPIFY_SHOP_1`, `SHOPIFY_ADMIN_TOKEN_1`, `SHOPIFY_SHOP_2` and `SHOPIFY_ADMIN_TOKEN_2` with your Shopify store domains and tokens. An example `.env` file is provided.
+2. Configure the environment variables. See the **Configuration** section below for details.
 3. (Optional) You can still use `URL_1` and `URL_2` for the original counter endpoints.
 4. Start the development server with `vercel dev`.
 5. Open `index.html` in your browser to see the counter.
@@ -23,9 +23,23 @@ The page now includes a small hamburger menu in the top-right corner for quick n
 Use the **Settings** link in that menu to open a page with a table for recording monthly goals for the year.
 Each month's goal is stored separately in `localStorage`. When the month changes the counter page reads the goal for that month so the values persist without a backend.
 
+## Configuration
+
+Copy `.env.example` to `.env` and provide values for the variables. The required fields specify the Shopify stores and their admin API tokens. Optional settings let you change the legacy counter URLs, whitelist additional hosts or supply an `API_KEY` to secure the endpoints. Refer to `.env.example` for the complete list of names.
+
 ## API Access
 
 Set the `API_KEY` environment variable to restrict access to the `/api/shopify-counter` route. When a key is set, requests must include the same value in the `x-api-key` header or the API responds with `401 Unauthorized`. Leave `API_KEY` unset to allow unrestricted access.
+
+### Usage
+
+Filter the count by time period using the `period` query parameter:
+
+- `/api/shopify-counter?period=month` – orders placed since the start of the current month
+- `/api/shopify-counter?period=year` – orders placed since the start of the current year
+- `/api/shopify-counter?period=all` – all orders regardless of date
+
+If the `created_at_min` parameter is supplied it takes precedence over `period` and should contain an ISO timestamp.
 
 ## Running tests
 

--- a/api/shopify-counter.js
+++ b/api/shopify-counter.js
@@ -15,8 +15,31 @@ async function fetchCount(shop, token, createdAtMin) {
   return data.count || 0;
 }
 
+function startOfMonth() {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
+}
+
+function startOfYear() {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), 0, 1)).toISOString();
+}
+
 module.exports = async (req, res) => {
-  const createdAtMin = req.query?.created_at_min;
+  let createdAtMin = req.query?.created_at_min;
+  const period = req.query?.period;
+  if (!createdAtMin && period) {
+    if (period === 'month') {
+      createdAtMin = startOfMonth();
+    } else if (period === 'year') {
+      createdAtMin = startOfYear();
+    } else if (period === 'all') {
+      createdAtMin = undefined;
+    } else {
+      res.status(400).json({ error: 'Invalid period' });
+      return;
+    }
+  }
   const requiredKey = process.env.API_KEY;
   if (requiredKey) {
     const provided = req.headers['x-api-key'] || '';

--- a/test/shopify-counter.test.js
+++ b/test/shopify-counter.test.js
@@ -34,3 +34,24 @@ test('returns 401 when api key missing', async () => {
   await handler(req, res);
   assert.strictEqual(res.statusCode, 401);
 });
+
+test('period=all omits created_at_min', async () => {
+  const urls = [];
+  const originalFetch = global.fetch;
+  global.fetch = async url => { urls.push(url.toString()); return { json: async () => ({ count: 1 }) }; };
+  process.env.API_KEY = '';
+  const req = { headers: {}, query: { period: 'all' } };
+  const res = createRes();
+  await handler(req, res);
+  const parsed = new URL(urls[0]);
+  assert.ok(!parsed.searchParams.has('created_at_min'));
+  global.fetch = originalFetch;
+});
+
+test('invalid period returns 400', async () => {
+  process.env.API_KEY = '';
+  const req = { headers: {}, query: { period: 'week' } };
+  const res = createRes();
+  await handler(req, res);
+  assert.strictEqual(res.statusCode, 400);
+});


### PR DESCRIPTION
## Summary
- support `period` query in `/api/shopify-counter`
- provide `.env.example`
- explain required environment variables in new Configuration section of the README
- document period-based API usage in README
- test the new API behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853f38561448330a9d8ad5bce5e8342