### PR TITLE
Add test for second shop fetch failure

### DIFF
--- a/test/shopify-counter.test.js
+++ b/test/shopify-counter.test.js
@@ -96,6 +96,23 @@ test('returns error when a shop fetch fails', async () => {
   global.fetch = originalFetch;
 });
 
+test('returns error when a second shop fetch fails', async () => {
+  const originalFetch = global.fetch;
+  let call = 0;
+  global.fetch = async () => {
+    call++;
+    if (call === 2) throw new Error('boom');
+    return { ok: true, status: 200, json: async () => ({ count: 1 }) };
+  };
+  process.env.API_KEY = '';
+  const req = { headers: {}, query: {} };
+  const res = createRes();
+  await handler(req, res);
+  assert.strictEqual(res.statusCode, 502);
+  assert.deepStrictEqual(res.body, { error: 'Failed to fetch count from shop 2' });
+  global.fetch = originalFetch;
+});
+
 test('returns 401 when api key missing', async () => {
   process.env.API_KEY = 'secret';
   const req = { headers: {} };


### PR DESCRIPTION
## Summary
- add regression test for failing second shop request

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'searchParams'))*

------
https://chatgpt.com/codex/tasks/task_e_6853f9571c58833086b67b4ecc354907