### PR TITLE
Update API README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ Each month's goal is stored separately in `localStorage`. When the month changes
 
 Set the `API_KEY` environment variable to restrict access to the `/api/shopify-counter` route. When a key is set, requests must include the same value in the `x-api-key` header or the API responds with `401 Unauthorized`. Leave `API_KEY` unset to allow unrestricted access.
 
+## API Usage
+
+The `/api/shopify-counter` endpoint accepts two optional query parameters. Use
+`period` to choose a built‑in date range:
+
+- `month` (default) &ndash; count orders from the first of the current month.
+- `year` &ndash; count orders from the start of the current year.
+- `all` &ndash; include all orders.
+
+The calculated start date can be overridden with `created_at_min`, which accepts
+an ISO 8601 timestamp.
+
+Example requests:
+
+```bash
+curl 'https://example.com/api/shopify-counter?period=year'
+curl 'https://example.com/api/shopify-counter?created_at_min=2024-04-01T00:00:00Z'
+```
+
 ## Running tests
 
 Run the test suite with:

--- a/test/shopify-counter.test.js
+++ b/test/shopify-counter.test.js
@@ -32,7 +32,7 @@ test('uses start of current month by default', async () => {
   const urls = [];
   global.fetch = async (url) => {
     urls.push(url);
-    return { json: async () => ({ count: 1 }) };
+    return { ok: true, status: 200, json: async () => ({ count: 1 }) };
   };
   process.env.API_KEY = '';
   const req = { headers: {}, query: {} };
@@ -50,7 +50,7 @@ test('uses start of current year when period=year', async () => {
   const urls = [];
   global.fetch = async (url) => {
     urls.push(url);
-    return { json: async () => ({ count: 1 }) };
+    return { ok: true, status: 200, json: async () => ({ count: 1 }) };
   };
   process.env.API_KEY = '';
   const req = { headers: {}, query: { period: 'year' } };
@@ -68,7 +68,7 @@ test('omits created_at_min when period=all', async () => {
   const urls = [];
   global.fetch = async (url) => {
     urls.push(url);
-    return { json: async () => ({ count: 1 }) };
+    return { ok: true, status: 200, json: async () => ({ count: 1 }) };
   };
   process.env.API_KEY = '';
   const req = { headers: {}, query: { period: 'all' } };


### PR DESCRIPTION
## Summary
- document optional `period` query and `created_at_min` override
- update API tests to satisfy new response handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853f9559c5c833097ebf7b49bb3a510