### PR TITLE
Improve env validation and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This simple project displays a counter on a web page and updates it from a serve
 ## Setup
 
 1. Install dependencies (Node 18 or newer is required but no extra packages are needed).
-2. Set the environment variables `SHOPIFY_SHOP_1`, `SHOPIFY_ADMIN_TOKEN_1`, `SHOPIFY_SHOP_2` and `SHOPIFY_ADMIN_TOKEN_2` with your Shopify store domains and tokens. Copy `.env.example` to `.env` and replace the placeholder values.
+2. Set the environment variables `SHOPIFY_SHOP_1`, `SHOPIFY_ADMIN_TOKEN_1`, `SHOPIFY_SHOP_2` and `SHOPIFY_ADMIN_TOKEN_2` with your Shopify store domains and tokens. Values must look like `my-store.myshopify.com` and the tokens must be valid. These variables are required for both preview and production deployments. Copy `.env.example` to `.env` and replace the placeholder values.
 3. (Optional) You can still use `URL_1` and `URL_2` for the original counter endpoints.
 4. Start the development server with `vercel dev`.
 5. Open `index.html` in your browser to see the counter.
@@ -44,6 +44,16 @@ Example requests:
 ```bash
 curl 'https://example.com/api/shopify-counter?period=year'
 curl 'https://example.com/api/shopify-counter?created_at_min=2024-04-01T00:00:00Z'
+```
+
+The API returns the combined order count along with counts for each shop:
+
+```json
+{
+  "number": 42,
+  "butikk1": 21,
+  "butikk2": 21
+}
 ```
 
 ## Running tests

--- a/index.html
+++ b/index.html
@@ -260,6 +260,10 @@ async function updateCounter() {
     const query = params.toString();
     const res = await fetch('/api/shopify-counter' + (query ? '?' + query : ''));
     const data = await res.json();
+    if (data.error) {
+      console.error('Counter API error:', data.error);
+      return;
+    }
     const value = data.number ?? 0;
     if (value !== currentValue) {
       animateCounter(value, target);

--- a/test/shopify-counter.test.js
+++ b/test/shopify-counter.test.js
@@ -1,8 +1,8 @@
 const test = require('node:test');
 const assert = require('node:assert');
-process.env.SHOPIFY_SHOP_1 = 'shop1';
+process.env.SHOPIFY_SHOP_1 = 'shop1.myshopify.com';
 process.env.SHOPIFY_ADMIN_TOKEN_1 = 't1';
-process.env.SHOPIFY_SHOP_2 = 'shop2';
+process.env.SHOPIFY_SHOP_2 = 'shop2.myshopify.com';
 process.env.SHOPIFY_ADMIN_TOKEN_2 = 't2';
 const handler = require('../api/shopify-counter.js');
 


### PR DESCRIPTION
## Summary
- log errors from the counter API instead of showing zeroes
- validate Shopify environment variables before processing requests
- write detailed errors when Shopify requests fail
- update example tests with valid Shopify domains
- document required env vars and API response format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853ff4806b483308a74cc70050bb63f