### PR TITLE
Add Shopify API troubleshooting

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,9 +262,15 @@ async function updateCounter() {
     const data = await res.json();
     if (data.error) {
       console.error('Counter API error:', data.error);
+      animateCounter(0, target);
+      currentValue = 0;
       return;
     }
-    const value = data.number ?? 0;
+    let value = Number(data.number ?? 0);
+    if (!Number.isFinite(value) || value < 0 || value > 1000000) {
+      console.error('Invalid counter value:', data.number);
+      value = 0;
+    }
     if (value !== currentValue) {
       animateCounter(value, target);
       currentValue = value;

--- a/test/shopify-counter.test.js
+++ b/test/shopify-counter.test.js
@@ -92,7 +92,7 @@ test('returns error when a shop fetch fails', async () => {
   const res = createRes();
   await handler(req, res);
   assert.strictEqual(res.statusCode, 502);
-  assert.deepStrictEqual(res.body, { error: 'Failed to fetch count from shop 1' });
+  assert.deepStrictEqual(res.body, { number: 0, error: 'Failed to fetch count from shop 1' });
   global.fetch = originalFetch;
 });
 
@@ -109,7 +109,7 @@ test('returns error when a second shop fetch fails', async () => {
   const res = createRes();
   await handler(req, res);
   assert.strictEqual(res.statusCode, 502);
-  assert.deepStrictEqual(res.body, { error: 'Failed to fetch count from shop 2' });
+  assert.deepStrictEqual(res.body, { number: 0, error: 'Failed to fetch count from shop 2' });
   global.fetch = originalFetch;
 });
 


### PR DESCRIPTION
## Summary
- improve logging in `fetchCount` and include count `0` in error responses
- handle API errors in front-end
- document API troubleshooting steps
- adjust tests for new error responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854047a06388330a6ad92fb3d8d218c