### PR TITLE
Fix Shopify count for closed orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ Follow these steps if the API does not return the expected counts after deployme
    numbers.
 6. If something fails, log the problem clearly and return a meaningful error
    response instead of dummy values.
- pe16f0-codex/fix-api-functionality
+
+When counting orders the API now sends the query parameter `status=any` so that
+archived and closed orders are included. Make sure your admin tokens have the
+`read_orders` scope.
 
 ## Slik feilsøker du API-integrasjon
 
@@ -112,5 +115,3 @@ Follow these steps if the API does not return the expected counts after deployme
    dette skjer.
 4. Sjekk antall ordre i Shopify Admin for valgt periode og sammenlign med
    verdien fra `/api/shopify-counter`. Tallene skal matche.
-=======
- main

--- a/api/shopify-counter.js
+++ b/api/shopify-counter.js
@@ -28,6 +28,8 @@ async function fetchCount(shop, token, createdAtMin) {
   }
   const url = new URL(`/admin/api/2024-04/orders/count.json`, `https://${shop}`);
   if (createdAtMin) url.searchParams.set('created_at_min', createdAtMin);
+  // count all orders including closed/archived ones
+  url.searchParams.set('status', 'any');
   const tokenId = token.slice(0, 6);
   console.log(`Fetching ${url} with token ${tokenId}...`);
   const res = await fetch(url, {


### PR DESCRIPTION
## Summary
- include `status=any` when counting Shopify orders so archived and closed orders are included
- document the new behavior in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68540bfb0c048330903178bb0ac26732