### PR TITLE
Return error message from API on failure

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -100,8 +100,8 @@ module.exports = async (req, res) => {
 
         res.json({ number: total });
     } catch (error) {
-        // If an error occurs, return 0 to avoid breaking the counter
+        // If an error occurs, return 0 and include the error message
         console.error('Failed to fetch counters', error);
-        res.json({ number: 0 });
+        res.status(502).json({ number: 0, error: error.message });
     }
 };


### PR DESCRIPTION
## Summary
- return a 502 status with the error message when `api/index.js` fails to fetch counters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685540f89cc083308dd66fdef0fa4fe6