### PR TITLE
Implement created_at_min override

### DIFF
--- a/api/shopify-counter.js
+++ b/api/shopify-counter.js
@@ -86,6 +86,13 @@ module.exports = async (req, res) => {
   } else {
     createdAtMin = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
   }
+  if (req.query?.created_at_min) {
+    const provided = req.query.created_at_min;
+    const isoRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/;
+    if (isoRegex.test(provided) && !isNaN(new Date(provided).getTime())) {
+      createdAtMin = provided;
+    }
+  }
   const requiredKey = process.env.API_KEY;
   if (requiredKey) {
     const provided = req.headers['x-api-key'] || '';

--- a/test/shopify-counter.test.js
+++ b/test/shopify-counter.test.js
@@ -79,6 +79,23 @@ test('omits created_at_min when period=all', async () => {
   global.fetch = originalFetch;
 });
 
+test('uses provided created_at_min when valid', async () => {
+  const originalFetch = global.fetch;
+  const urls = [];
+  global.fetch = async (url) => {
+    urls.push(url);
+    return { ok: true, status: 200, json: async () => ({ count: 1 }) };
+  };
+  process.env.API_KEY = '';
+  const value = '2023-08-01T00:00:00Z';
+  const req = { headers: {}, query: { created_at_min: value } };
+  const res = createRes();
+  await handler(req, res);
+  assert.strictEqual(urls[0].searchParams.get('created_at_min'), value);
+  assert.strictEqual(urls[1].searchParams.get('created_at_min'), value);
+  global.fetch = originalFetch;
+});
+
 test('returns error when a shop fetch fails', async () => {
   const originalFetch = global.fetch;
   let call = 0;


### PR DESCRIPTION
## Summary
- support a `created_at_min` query parameter for custom start dates
- add regression test for created_at_min override

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855535c49048330b304279a4a207e2b