### PR TITLE
Add Shopify created_at_max support

### DIFF
--- a/test/shopify-counter.test.js
+++ b/test/shopify-counter.test.js
@@ -79,6 +79,30 @@ test('omits created_at_min when period=all', async () => {
   global.fetch = originalFetch;
 });
 
+test('forwards created_at_min and created_at_max query params', async () => {
+  const originalFetch = global.fetch;
+  const urls = [];
+  global.fetch = async (url) => {
+    urls.push(url);
+    return { ok: true, status: 200, json: async () => ({ count: 1 }) };
+  };
+  process.env.API_KEY = '';
+  const req = {
+    headers: {},
+    query: {
+      created_at_min: '2024-05-01T00:00:00Z',
+      created_at_max: '2024-05-31T23:59:59Z'
+    }
+  };
+  const res = createRes();
+  await handler(req, res);
+  assert.strictEqual(urls[0].searchParams.get('created_at_min'), '2024-05-01T00:00:00Z');
+  assert.strictEqual(urls[0].searchParams.get('created_at_max'), '2024-05-31T23:59:59Z');
+  assert.strictEqual(urls[1].searchParams.get('created_at_min'), '2024-05-01T00:00:00Z');
+  assert.strictEqual(urls[1].searchParams.get('created_at_max'), '2024-05-31T23:59:59Z');
+  global.fetch = originalFetch;
+});
+
 test('returns error when a shop fetch fails', async () => {
   const originalFetch = global.fetch;
   let call = 0;


### PR DESCRIPTION
## Summary
- allow overriding the minimum and maximum created date
- forward `created_at_max` to Shopify API
- test forwarding of min and max dates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855535d0ff48330962604fa85c6e725