### PR TITLE
Clean up merge artifacts and validate date range

### DIFF
--- a/api/shopify-counter.js
+++ b/api/shopify-counter.js
@@ -89,15 +89,11 @@ module.exports = async (req, res) => {
     createdAtMin = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
   }
   if (req.query?.created_at_min) {
- me19lw-codex/extend-fetchcount-to-handle-createdatmax
-    createdAtMin = req.query.created_at_min;
-=======
     const provided = req.query.created_at_min;
     const isoRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/;
     if (isoRegex.test(provided) && !isNaN(new Date(provided).getTime())) {
       createdAtMin = provided;
     }
- main
   }
   const requiredKey = process.env.API_KEY;
   if (requiredKey) {

--- a/test/shopify-counter.test.js
+++ b/test/shopify-counter.test.js
@@ -79,11 +79,7 @@ test('omits created_at_min when period=all', async () => {
   global.fetch = originalFetch;
 });
 
- me19lw-codex/extend-fetchcount-to-handle-createdatmax
 test('forwards created_at_min and created_at_max query params', async () => {
-=======
-test('uses provided created_at_min when valid', async () => {
-  main
   const originalFetch = global.fetch;
   const urls = [];
   global.fetch = async (url) => {
@@ -91,7 +87,6 @@ test('uses provided created_at_min when valid', async () => {
     return { ok: true, status: 200, json: async () => ({ count: 1 }) };
   };
   process.env.API_KEY = '';
- me19lw-codex/extend-fetchcount-to-handle-createdatmax
   const req = {
     headers: {},
     query: {
@@ -105,14 +100,23 @@ test('uses provided created_at_min when valid', async () => {
   assert.strictEqual(urls[0].searchParams.get('created_at_max'), '2024-05-31T23:59:59Z');
   assert.strictEqual(urls[1].searchParams.get('created_at_min'), '2024-05-01T00:00:00Z');
   assert.strictEqual(urls[1].searchParams.get('created_at_max'), '2024-05-31T23:59:59Z');
-=======
+  global.fetch = originalFetch;
+});
+
+test('uses provided created_at_min when valid', async () => {
+  const originalFetch = global.fetch;
+  const urls = [];
+  global.fetch = async (url) => {
+    urls.push(url);
+    return { ok: true, status: 200, json: async () => ({ count: 1 }) };
+  };
+  process.env.API_KEY = '';
   const value = '2023-08-01T00:00:00Z';
   const req = { headers: {}, query: { created_at_min: value } };
   const res = createRes();
   await handler(req, res);
   assert.strictEqual(urls[0].searchParams.get('created_at_min'), value);
   assert.strictEqual(urls[1].searchParams.get('created_at_min'), value);
- main
   global.fetch = originalFetch;
 });
 


### PR DESCRIPTION
## Summary
- clean merge leftovers in `shopify-counter.js`
- validate `created_at_min` query param
- remove conflict markers from tests
- verify both `created_at_min` and `created_at_max` forwarding
- check passing tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685557d9a53083309c18ab7bc365f5b7