### PR TITLE
Add frontend error handling for counter

### DIFF
--- a/api/shopify-counter.js
+++ b/api/shopify-counter.js
@@ -89,15 +89,11 @@ module.exports = async (req, res) => {
     createdAtMin = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
   }
   if (req.query?.created_at_min) {
- me19lw-codex/extend-fetchcount-to-handle-createdatmax
-    createdAtMin = req.query.created_at_min;
-=======
     const provided = req.query.created_at_min;
     const isoRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/;
     if (isoRegex.test(provided) && !isNaN(new Date(provided).getTime())) {
       createdAtMin = provided;
     }
- main
   }
   const requiredKey = process.env.API_KEY;
   if (requiredKey) {

--- a/index.html
+++ b/index.html
@@ -111,6 +111,11 @@ body {
     margin-top: 10px;
     font-size: 1.5vw;
   }
+  #error-msg {
+    margin-top: 10px;
+    color: red;
+    font-size: 1.2vw;
+  }
 </style>
 </head>
 <body>
@@ -147,6 +152,7 @@ body {
   <div id="api-controls">
     <div id="api-checkboxes"></div>
   </div>
+  <div id="error-msg"></div>
   <div id="slider-container">
     <label for="goal-slider">Monthly goal:</label>
     <input type="range" id="goal-slider" min="100000" max="1000000" step="1000">
@@ -169,6 +175,7 @@ const customDates = document.getElementById('custom-dates');
 const startInput = document.getElementById('custom-start');
 const endInput = document.getElementById('custom-end');
 const periodDisplay = document.getElementById('active-period');
+const errorElement = document.getElementById('error-msg');
 
 let apiList = JSON.parse(localStorage.getItem('apiList') || '[]');
 if (apiList.length === 0) {
@@ -335,13 +342,19 @@ async function updateCounter() {
     if (enabled.length === 0) params.set('source', 'none');
     const query = params.toString();
     const res = await fetch('/api/shopify-counter' + (query ? '?' + query : ''));
-    const data = await res.json();
-    if (data.error) {
-      console.error('Counter API error:', data.error);
-      animateCounter(0, target);
-      currentValue = 0;
+    let data;
+    try {
+      data = await res.json();
+    } catch (jsonErr) {
+      throw new Error('Invalid JSON');
+    }
+    if (!res.ok || data.error) {
+      const msg = data.error || `Status ${res.status}`;
+      console.error('Counter API error:', msg);
+      errorElement.textContent = msg;
       return;
     }
+    errorElement.textContent = '';
     let value = Number(data.number ?? 0);
     if (!Number.isFinite(value) || value < 0 || value > 1000000) {
       console.error('Invalid counter value:', data.number);
@@ -357,6 +370,7 @@ async function updateCounter() {
     }
   } catch (err) {
     console.error('Failed to fetch counter:', err);
+    errorElement.textContent = err.message;
   }
 }
 

--- a/test/shopify-counter.test.js
+++ b/test/shopify-counter.test.js
@@ -79,11 +79,7 @@ test('omits created_at_min when period=all', async () => {
   global.fetch = originalFetch;
 });
 
- me19lw-codex/extend-fetchcount-to-handle-createdatmax
 test('forwards created_at_min and created_at_max query params', async () => {
-=======
-test('uses provided created_at_min when valid', async () => {
-  main
   const originalFetch = global.fetch;
   const urls = [];
   global.fetch = async (url) => {
@@ -91,7 +87,6 @@ test('uses provided created_at_min when valid', async () => {
     return { ok: true, status: 200, json: async () => ({ count: 1 }) };
   };
   process.env.API_KEY = '';
- me19lw-codex/extend-fetchcount-to-handle-createdatmax
   const req = {
     headers: {},
     query: {
@@ -105,14 +100,6 @@ test('uses provided created_at_min when valid', async () => {
   assert.strictEqual(urls[0].searchParams.get('created_at_max'), '2024-05-31T23:59:59Z');
   assert.strictEqual(urls[1].searchParams.get('created_at_min'), '2024-05-01T00:00:00Z');
   assert.strictEqual(urls[1].searchParams.get('created_at_max'), '2024-05-31T23:59:59Z');
-=======
-  const value = '2023-08-01T00:00:00Z';
-  const req = { headers: {}, query: { created_at_min: value } };
-  const res = createRes();
-  await handler(req, res);
-  assert.strictEqual(urls[0].searchParams.get('created_at_min'), value);
-  assert.strictEqual(urls[1].searchParams.get('created_at_min'), value);
- main
   global.fetch = originalFetch;
 });
 


### PR DESCRIPTION
## Summary
- show backend errors on the home page
- keep previous value when `updateCounter` fails
- clean up merge artefacts in tests and API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685557da1ed4833098c365e4203d5d21