### PR TITLE
feat: add multi-shop env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,10 @@
 # Example environment variables
 # Replace with your actual values
 
-SHOPIFY_SHOP_1=shop1.myshopify.com
-SHOPIFY_ADMIN_TOKEN_1=token1
-SHOPIFY_SHOP_2=shop2.myshopify.com
-SHOPIFY_ADMIN_TOKEN_2=token2
+# Comma-separated list of allowed shop domains
+ALLOWED_SHOPS=shop1.myshopify.com,shop2.myshopify.com
+# Tokens are named SHOPIFY_TOKEN__ + uppercased shop domain with punctuation replaced by underscores
+SHOPIFY_TOKEN__SHOP1_MYSHOPIFY_COM=token1
+SHOPIFY_TOKEN__SHOP2_MYSHOPIFY_COM=token2
+SHOPIFY_API_VERSION=2025-07
 API_KEY=your_api_key_here

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This simple project displays a counter on a web page and updates it from a serve
 ## Setup
 
 1. Install dependencies with `npm install` (Node 18 or newer is required). This includes the Vercel CLI for running the development server.
-2. Set the environment variables `SHOPIFY_SHOP_1`, `SHOPIFY_ADMIN_TOKEN_1`, `SHOPIFY_SHOP_2` and `SHOPIFY_ADMIN_TOKEN_2` with your Shopify store domains and tokens. Values must look like `my-store.myshopify.com` and the tokens must be valid. These variables are required for both preview and production deployments. Copy `.env.example` to `.env` and replace the placeholder values. Define the same variables in your Vercel project to use them in deployed environments.
+2. Set the environment variables `ALLOWED_SHOPS`, `SHOPIFY_API_VERSION` and one `SHOPIFY_TOKEN__<SHOP>` for each store. `ALLOWED_SHOPS` is a comma-separated list of `myshopify.com` domains. Tokens follow the naming rule `SHOPIFY_TOKEN__` + uppercased shop domain with punctuation replaced by underscores (e.g. `SHOPIFY_TOKEN__SHOP1_MYSHOPIFY_COM`). Copy `.env.example` to `.env` and replace the placeholder values. Define the same variables in your Vercel project to use them in deployed environments.
 3. (Optional) You can still use `URL_1` and `URL_2` for the original counter endpoints.
 4. Start the development server with `vercel dev`.
 5. Open `index.html` in your browser to see the counter.
@@ -55,8 +55,8 @@ The API returns the combined order count along with counts for each shop:
 ```json
 {
   "number": 42,
-  "butikk1": 21,
-  "butikk2": 21
+  "shop1.myshopify.com": 21,
+  "shop2.myshopify.com": 21
 }
 ```
 
@@ -74,10 +74,7 @@ This command executes `node --test` under the hood.
 
 Follow these steps if the API does not return the expected counts after deployment:
 
-1. In Vercel, ensure the variables `SHOPIFY_SHOP_1`, `SHOPIFY_ADMIN_TOKEN_1`,
-   `SHOPIFY_SHOP_2` and `SHOPIFY_ADMIN_TOKEN_2` are defined for both *Production*
-   and *Preview* environments. The shop values must be your `myshopify.com`
-   domains without `https://`, and the tokens must be valid admin tokens.
+1. In Vercel, ensure `ALLOWED_SHOPS`, `SHOPIFY_API_VERSION` and one `SHOPIFY_TOKEN__<SHOP>` variable per shop are defined for both *Production* and *Preview* environments. The shop values must be your `myshopify.com` domains without `https://`, and the tokens must be valid admin tokens.
 2. Confirm that the tokens include the `read_orders` scope and that the app is
    installed and active in each store.
 3. After updating any variables, trigger a redeploy so the new values are
@@ -106,7 +103,7 @@ archived and closed orders are included. Make sure your admin tokens have the
 
    ```bash
    curl -H "X-Shopify-Access-Token: <TOKEN>" \
-     https://<SHOP>.myshopify.com/admin/api/2025-04/orders/count.json
+     https://<SHOP>.myshopify.com/admin/api/2025-07/orders/count.json
    ```
 
    Svaret bør være på formen `{ "count": n }`. Hvis du ikke får et gyldig tall,

--- a/test/shopify-counter.test.js
+++ b/test/shopify-counter.test.js
@@ -1,9 +1,9 @@
 const test = require('node:test');
 const assert = require('node:assert');
-process.env.SHOPIFY_SHOP_1 = 'shop1.myshopify.com';
-process.env.SHOPIFY_ADMIN_TOKEN_1 = 't1';
-process.env.SHOPIFY_SHOP_2 = 'shop2.myshopify.com';
-process.env.SHOPIFY_ADMIN_TOKEN_2 = 't2';
+process.env.ALLOWED_SHOPS = 'shop1.myshopify.com,shop2.myshopify.com';
+process.env.SHOPIFY_TOKEN__SHOP1_MYSHOPIFY_COM = 't1';
+process.env.SHOPIFY_TOKEN__SHOP2_MYSHOPIFY_COM = 't2';
+process.env.SHOPIFY_API_VERSION = '2025-07';
 const handler = require('../api/shopify-counter.js');
 
 // helper to create mock response object
@@ -23,7 +23,11 @@ test('sums counts from both shops', async () => {
   const req = { headers: {}, query: {} };
   const res = createRes();
   await handler(req, res);
-  assert.deepStrictEqual(res.body, { number: 3, butikk1: 1, butikk2: 2 });
+  assert.deepStrictEqual(res.body, {
+    number: 3,
+    'shop1.myshopify.com': 1,
+    'shop2.myshopify.com': 2,
+  });
   global.fetch = originalFetch;
 });
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,10 @@
 {
   "version": 2,
+  "env": {
+    "ALLOWED_SHOPS": "9rds.myshopify.com",
+    "SHOPIFY_TOKEN__9RDS_MYSHOPIFY_COM": "<Admin API token with read_orders>",
+    "SHOPIFY_API_VERSION": "2025-07"
+  },
   "routes": [
     { "src": "/api/shopify-counter", "dest": "/api/shopify-counter.js" },
     { "src": "/api/(.*)", "dest": "/api/index.js" }


### PR DESCRIPTION
## Summary
- support multiple Shopify shops via `ALLOWED_SHOPS` and `SHOPIFY_TOKEN__<SHOP>` env vars
- read `SHOPIFY_API_VERSION` for API calls and document naming convention
- add deployment env placeholders and update docs and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46ee3ec948330b2856afc061c13d5