### PR TITLE
Refactor health endpoint and add counter route

### DIFF
--- a/app/api/counter/route.ts
+++ b/app/api/counter/route.ts
@@ -1,0 +1,42 @@
+export const runtime = "nodejs";
+
+// Reuse existing counter handler implemented in legacy api/index.js
+// @ts-ignore - no type definitions for legacy module
+import legacyHandler from "@/api/index.js";
+
+export async function GET(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const headers = Object.fromEntries(request.headers.entries());
+  const query: Record<string, string | string[]> = {};
+  for (const [key, value] of url.searchParams.entries()) {
+    if (query[key]) {
+      const current = query[key];
+      if (Array.isArray(current)) {
+        current.push(value);
+      } else {
+        query[key] = [current, value];
+      }
+    } else {
+      query[key] = value;
+    }
+  }
+
+  return await new Promise((resolve) => {
+    const res = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(body: any) {
+        resolve(
+          new Response(JSON.stringify(body), {
+            status: this.statusCode || 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        );
+      },
+    };
+    legacyHandler({ headers, query }, res);
+  });
+}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,9 +1,13 @@
 export const runtime = "nodejs";
 
+import { getAllowedShops, getTokenForShop } from "@/lib/shopify";
+
 export function GET() {
-  return Response.json({
-    shop: process.env.SHOPIFY_SHOP,
-    tokenExists: !!process.env.SHOPIFY_TOKEN,
-    apiVersion: process.env.SHOPIFY_API_VERSION,
-  });
+  const apiVersion = process.env.SHOPIFY_API_VERSION;
+  const shops = getAllowedShops();
+  const allowedShops = shops.map((shop) => ({
+    shop,
+    tokenExists: !!getTokenForShop(shop),
+  }));
+  return Response.json({ apiVersion, allowedShops });
 }

--- a/lib/shopify.ts
+++ b/lib/shopify.ts
@@ -1,0 +1,27 @@
+export function getAllowedShops(): string[] {
+  const shops: string[] = [];
+  for (const [key, value] of Object.entries(process.env)) {
+    if (!value) continue;
+    // look for env vars like SHOPIFY_SHOP, SHOPIFY_SHOP_1, SHOPIFY_SHOP_2, etc
+    if (key === "SHOPIFY_SHOP" || /^SHOPIFY_SHOP_\d+$/.test(key)) {
+      shops.push(value);
+    }
+  }
+  return shops;
+}
+
+export function getTokenForShop(shop: string): string | undefined {
+  // find matching shop variable and infer corresponding token
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== shop) continue;
+    if (key === "SHOPIFY_SHOP") {
+      return process.env.SHOPIFY_TOKEN;
+    }
+    const suffix = key.replace(/^SHOPIFY_SHOP/, "");
+    return (
+      process.env[`SHOPIFY_ADMIN_TOKEN${suffix}`] ||
+      process.env[`SHOPIFY_TOKEN${suffix}`]
+    );
+  }
+  return undefined;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["app/**/*", "lib/**/*", "api/**/*", "test/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- overhaul `/api/health` to report API version and token presence for all allowed shops
- add Shopify helpers for reading allowed shops and tokens
- expose legacy counter logic via new `/api/counter` route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b46ee1eb4883309ce0737b54edb55c