### PR TITLE
chore(api): remove legacy pages/api health & sales routes, keep only App Router implementations

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,8 +4,5 @@
     "SHOPIFY_SHOP": "9rds.myshopify.com",
     "SHOPIFY_TOKEN": "<Admin API token with read_orders>",
     "SHOPIFY_API_VERSION": "2025-07"
-  },
-  "routes": [
-    { "src": "/api/(.*)", "dest": "/api/index.js" }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary
- remove catch-all `/api` rewrite so that `/api/health` and `/api/sales` use Next.js App Router implementations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b47759e97c8330a3ae5d9347a8222d