### PR TITLE
Add health endpoint exposing allowed Shopify shops

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -1,0 +1,11 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const shopify_1 = require("../lib/shopify");
+function handler(req, res) {
+    const allowedShops = (0, shopify_1.getAllowedShops)().map((shop) => ({
+        shop,
+        tokenExists: Boolean((0, shopify_1.getTokenForShop)(shop)),
+    }));
+    res.status(200).json({ apiVersion: (0, shopify_1.apiVersion)(), allowedShops });
+}
+exports.default = handler;

--- a/api/health.ts
+++ b/api/health.ts
@@ -1,0 +1,9 @@
+import { getAllowedShops, getTokenForShop, apiVersion } from "../lib/shopify";
+
+export default function handler(req: any, res: any) {
+  const allowedShops = getAllowedShops().map((shop) => ({
+    shop,
+    tokenExists: Boolean(getTokenForShop(shop)),
+  }));
+  res.status(200).json({ apiVersion: apiVersion(), allowedShops });
+}


### PR DESCRIPTION
## Summary
- add `/api/health` endpoint to report API version and allowed shops
- compile TypeScript health handler to JavaScript for deployment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4799a995c8330b9bd85672a33ef69